### PR TITLE
Absolute otp.config.hostname

### DIFF
--- a/src/client/js/otp/config.js
+++ b/src/client/js/otp/config.js
@@ -5,7 +5,7 @@ otp.config = {
     /**
      * The OTP web service locations
      */
-    hostname : "http://localhost:8080",
+    hostname : "", //"http://localhost:8080",
     //municoderHostname : "http://localhost:8080",
     //datastoreUrl : 'http://localhost:9000',
 	   // In the 0.10.x API the base path is "otp-rest-servlet/ws"


### PR DESCRIPTION
In order to test OTP across multiple machines on a local network (and where the server was bound to 0.0.0.0), I needed to remove the absolute hostname defined in otp.config.   

There may be other places where an absolute hostname is used in the client that should also be fixed if this is merged.
