### PR TITLE
Fix bus/bike linking code

### DIFF
--- a/src/main/java/org/opentripplanner/routing/impl/CandidateEdge.java
+++ b/src/main/java/org/opentripplanner/routing/impl/CandidateEdge.java
@@ -137,7 +137,7 @@ public class CandidateEdge {
         }
 
         // Calculate the score last so it can use all other data.
-        score = calcScore();
+         score = calcScore(mode);
     }
 
     /** Construct CandidateEdge based on a Coordinate. */
@@ -222,29 +222,47 @@ public class CandidateEdge {
         return out;
     }
 
-    /** Internal calculator for the score. Assumes that edge, platform and distance are initialized. */
-    private double calcScore() {
+    /** Internal calculator for the score. Assumes that edge, platform and distance are initialized. 
+     * @param mode */
+    private double calcScore(TraverseModeSet mode) {
         double myScore = 0;
         // why is this being scaled by 1/360th of the radius of the earth?
         myScore = distance * SphericalDistanceLibrary.RADIUS_OF_EARTH_IN_M / 360.0;
         myScore /= preference;
-        if ((edge.getStreetClass() & platform) != 0) {
-            // this a hack, but there's not really a better way to do it
-            myScore /= PLATFORM_PREFERENCE;
-        }
+        
         if (edge.getName().contains("sidewalk")) {
             // this is a hack, but there's not really a better way to do it
             myScore /= SIDEWALK_PREFERENCE;
         }
-        // apply strong preference to car edges and to platforms for the specified modes 
-        if (edge.getPermission().allows(StreetTraversalPermission.CAR)
-                || (edge.getStreetClass() & platform) != 0) {
-            // we're subtracting here because no matter how close we are to a
-            // good non-car non-platform edge, we really want to avoid it in
-            // case it's a Pedway or other weird and unlikely starting location.
-            myScore -= CAR_PREFERENCE;
-        }
 
+        if (mode.isTransit()) {
+        	if ((edge.getStreetClass() & platform) != 0) {
+        		// this a hack, but there's not really a better way to do it
+        		myScore /= PLATFORM_PREFERENCE;
+
+        		// apply strong preference to platforms for the specified modes 
+        			// we're subtracting here because no matter how close we are to a
+       	            // good non-car non-platform edge, we really want to avoid it in
+        	        // case it's a Pedway or other weird and unlikely starting location.
+        	        myScore -= CAR_PREFERENCE;
+        	}       
+        	
+        }
+        
+        if (mode.getDriving()) {
+        	// apply strong preference to car edges and to platforms for the specified modes 
+        	if (edge.getPermission().allows(StreetTraversalPermission.CAR)
+        			|| (edge.getStreetClass() & platform) != 0) {
+        		// we're subtracting here because no matter how close we are to a
+        		// good non-car non-platform edge, we really want to avoid it in
+        		// case it's a Pedway or other weird and unlikely starting location.
+        		//myScore -= CAR_PREFERENCE;
+        	}
+        } else if (mode.getBicycle()) {
+        	if (edge.getPermission().allows(StreetTraversalPermission.BICYCLE))
+        		myScore -= CAR_PREFERENCE;        	   
+        }                
+        
         // Consider the heading in the score if it is available.
         if (heading != null) {
             // If you are moving along the edge, score is not penalized.

--- a/src/main/java/org/opentripplanner/routing/impl/CandidateEdgeBundle.java
+++ b/src/main/java/org/opentripplanner/routing/impl/CandidateEdgeBundle.java
@@ -116,4 +116,14 @@ public class CandidateEdgeBundle extends ArrayList<CandidateEdge> {
         }
         return false;
     }
+
+	public boolean allowsWalking() {
+	    for (CandidateEdge ce : CandidateEdgeBundle.this) {
+	    	StreetEdge e = ce.getEdge();
+	    	if (e.getPermission().allows(StreetTraversalPermission.PEDESTRIAN)) {
+	    		return true;
+	    	}
+	    }
+		return false;
+	}
 }

--- a/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndexServiceImpl.java
+++ b/src/main/java/org/opentripplanner/routing/impl/StreetVertexIndexServiceImpl.java
@@ -378,7 +378,7 @@ public class StreetVertexIndexServiceImpl implements StreetVertexIndexService {
             if (best == null || bundle.best.score < best.best.score) {
                 if (possibleTransitLinksOnly) {
                     // assuming all platforms are tagged when they are not car streets... #1077 
-                    if (!(bundle.allowsCars() || bundle.isPlatform()))
+                    if (!(bundle.allowsWalking() || bundle.isPlatform()))
                         continue;
                 }
                 best = bundle;


### PR DESCRIPTION
This PR incorporates another technique (from upstream https://github.com/buma/OpenTripPlanner/compare/sloLinkingFix) for linking vertices to graph edges internally so that instead of heavily preferring "car" street edges even though a walking/bike edge may be closer.

This also seems to fix the odd trip plans with broken edges that Tracy reported.
