### PR TITLE
HART client fixes for issue#37

### DIFF
--- a/src/client/js/otp/layers/StopsLayer.js
+++ b/src/client/js/otp/layers/StopsLayer.js
@@ -86,8 +86,7 @@ otp.layers.StopsLayer =
 	    flag = false;
 	    for (x in stop.routes) {
 		r = stop.routes[x];
-		if (webapp.modules[0].busLayers.visible.indexOf(r.shortName) != -1 || 
-		    (otp.config.showHartBusStops && r.agency == "Hillsborough Area Regional Transit") ) {
+		if (otp.config.showHartBusStops && r.agency.name == "Hillsborough Area Regional Transit")  {
 			flag = true;
 			break;
 		}
@@ -134,7 +133,6 @@ otp.layers.StopsLayer =
                 }
             }
 
-          
             if(stop.agency == "USF Bull Runner" && otp.config.showBullRunnerStops == true){
             	//only want to display USF BullRunner stops in this layer
             	L.marker([stop.lat, stop.lon], {

--- a/src/client/js/otp/widgets/tripoptions/LayersWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/LayersWidget.js
@@ -88,7 +88,7 @@ otp.widgets.LayersWidget =
         });
       
 	// HART bus stops
-	$('#bus_hart').bind('click', {'this_': this}, function(ev) {
+	$('#bus_hart').bind('click', {'module': this.module}, function(ev) {
 
 		if (otp.config.showHartBusStops) {
 			otp.config.showHartBusStops = false;
@@ -99,7 +99,7 @@ otp.widgets.LayersWidget =
 			$("#bus_hart .box").addClass('active');
 		}
 
-		ev.data.this_.module.busLayers.refresh();
+		ev.data.module.stopsLayer.refresh();
 
 	});
   


### PR DESCRIPTION
Relatively simple client JS to fix missing HART stops

Routing should already be working after updating the GTFS data although more testing should be done on dev once this is merged to make sure the HART stop names and routes are correct ... currently I'm seeing "AGENCY#3" for a HART itinerary...
