### PR TITLE
Fix issue #34

### DIFF
--- a/src/client/js/otp/util/Text.js
+++ b/src/client/js/otp/util/Text.js
@@ -45,6 +45,7 @@ otp.util.Text = {
     constructUrlParamString : function(params) {
         var encodedParams = [];
         for(param in params) {
+	    if (params[param] == undefined) continue; // skip unset or invalid parameters so OTP doesn't complain later
             encodedParams.push(param+"="+ encodeURIComponent(params[param]));
         }
         return encodedParams.join("&");


### PR DESCRIPTION
Fix the constructUrlParamString function preventing it from encoding any parameters which are undefined because they cause problems with the OTP REST API later

Fix issue #34
