### PR TITLE
Replace stencil font for site-title

### DIFF
--- a/src/client/style.css
+++ b/src/client/style.css
@@ -374,7 +374,7 @@ body {
 
 #site-title a {
   text-decoration: none;
-  font-family: stencil;
+  font-family: 'Helvetica Neue', Arial, Helvetica, sans-serif;
   color: #9CCB3B;
 }
 /*


### PR DESCRIPTION
Replace stencil font for site-title to:
'Helvetica Neue', Arial, Helvetica, sans-serif

like the rest of the fonts.  Fixes #27
