### PR TITLE
Fix issue with case-sensitive POI Map

### DIFF
--- a/opentripplanner-geocoder/src/main/java/org/opentripplanner/geocoder/manual/ManualGeocoder.java
+++ b/opentripplanner-geocoder/src/main/java/org/opentripplanner/geocoder/manual/ManualGeocoder.java
@@ -36,16 +36,17 @@ public class ManualGeocoder implements Geocoder {
     	ArrayList<String> poiNames = new ArrayList<String>();
     	poiNames.addAll(pois.keySet());
     	
-        for (String name : poiNames) {
-        	name = name.toUpperCase();
+        for (String key : poiNames) {
+        	String name = key.toUpperCase();
         	String addr = address.toUpperCase();
         	if(name.contains(addr) || addr.contains(name)) {
-        		String value = (String)pois.get(name);
+        		String value = (String)pois.get(key);
         		String[] latlon = value.split(" ");
         		Double lat = Double.parseDouble(latlon[0]);
         		Double lon = Double.parseDouble(latlon[1]);
-        		String displayName = name;
-        		GeocoderResult geocoderResult = new GeocoderResult(lat, lon, displayName);
+
+			// Display the name exactly as it appears in the XML
+        		GeocoderResult geocoderResult = new GeocoderResult(lat, lon, key);
         		geocoderResults.add(geocoderResult);
         	}
         }


### PR DESCRIPTION
also preserve the case of POI Names in returned results.

With the name changes in https://github.com/CUTR-at-USF/usf-mobullity/pull/56 caused an NPE because the entry key is converted to uppercase for comparison.  This still uses touppercase to compare, but preserves the original case of the key for the result processing and also for display.
