### PR TITLE
Fix / and /index.html issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -431,26 +431,26 @@
         <dependency>
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
-            <version>2.8</version>
+            <version>2.13</version>
         </dependency>
         <!-- Deploy Jersey apps in stand-alone Grizzly server instead of a servlet container. -->
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-grizzly2-http</artifactId>
-            <version>2.8</version>
+            <version>2.13</version>
         </dependency>
 
         <!-- Jackson modules to serialize Jersey response objects to JSON. -->
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-json-provider</artifactId>
-            <version>2.3.3</version>
+            <version>2.4.3</version>
         </dependency>
         <!-- Jackson modules to serialize Jersey response objects to XML. -->
         <dependency>
             <groupId>com.fasterxml.jackson.jaxrs</groupId>
             <artifactId>jackson-jaxrs-xml-provider</artifactId>
-            <version>2.3.2</version>
+            <version>2.4.3</version>
         </dependency>
 
         <!-- Asynchronous Websocket-capable client, for message-driven incremental GTFS-RT -->

--- a/src/main/java/org/opentripplanner/standalone/OTPApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPApplication.java
@@ -1,5 +1,7 @@
 package org.opentripplanner.standalone;
 
+import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.fasterxml.jackson.jaxrs.xml.JacksonXMLProvider;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.glassfish.jersey.CommonProperties;
@@ -116,6 +118,10 @@ public class OTPApplication extends Application {
         return Sets.newHashSet (
             // Show exception messages in responses
             new OTPExceptionMapper(),
+            // Enable Jackson JSON response serialization
+            new JacksonJsonProvider(),
+            // Enable Jackson XML response serialization
+            new JacksonXMLProvider(),
             // Serialize POJOs (unannotated) JSON using Jackson
             new JSONObjectMapperProvider(),
             // Allow injecting the OTP server object into Jersey resource classes


### PR DESCRIPTION
The requirement #64 for / and /index.html apparently was a Grizzly/Jersey issue and is fixed upstream per issue #1415 by updating the jersey and grizzly dependencies via pom and adding two new json/xml providers.
