### PR TITLE
Fix 45 & 65 centering the map on relevant coordinates. Fix 69 bug when zooming too much.

### DIFF
--- a/src/client/js/otp/config.js
+++ b/src/client/js/otp/config.js
@@ -67,14 +67,14 @@ otp.config = {
     //set init lat lng in map.js with geolocation
     geoLocation: true,
     //if user does not allow location finding default location set
-    initLatLng : new L.LatLng(28.058499, -82.416945), 
-	mapBoundary: false,
+    initLatLng : new L.LatLng(28.061062, -82.413200), 
+    mapBoundary: false,
     initZoom : 15,
-    minZoom : 8,
+    minZoom : 9,
     maxZoom : 20,
     
     /* Whether the map should be moved to contain the full itinerary when a result is received. */
-    zoomToFitResults    : false,
+    zoomToFitResults    : true,
 
     	  
     /**

--- a/src/client/js/otp/config.js
+++ b/src/client/js/otp/config.js
@@ -72,6 +72,7 @@ otp.config = {
     initZoom : 15,
     minZoom : 9,
     maxZoom : 20,
+    gpsZoom : 17
     
     /* Whether the map should be moved to contain the full itinerary when a result is received. */
     zoomToFitResults    : true,

--- a/src/client/js/otp/core/Map.js
+++ b/src/client/js/otp/core/Map.js
@@ -99,12 +99,9 @@ otp.core.Map = otp.Class({
         $.ajax(url, {
             data: { routerId : otp.config.routerId },            
             dataType: 'JSON',
-            success: function(data) {				
-                this_.lmap.fitBounds([
-                    [data.lowerLeftLatitude, data.lowerLeftLongitude],
-                    [data.upperRightLatitude, data.upperRightLongitude]
-                ]);				
-				
+            
+            success: 
+            function(data) {				
 				otp.config.mapBoundary = new L.latLngBounds(new L.latLng(data.lowerLeftLatitude, data.lowerLeftLongitude), new L.latLng(data.upperRightLatitude, data.upperRightLongitude));
 		
 				if(otp.config.geoLocation){
@@ -213,6 +210,7 @@ otp.core.Map = otp.Class({
     
     activeModuleChanged : function(oldModule, newModule) {
         
+
         //console.log("actModChanged: "+oldModule+", "+newModule);
         
         // hide module-specific layers for "old" module, if applicable

--- a/src/client/js/otp/core/Map.js
+++ b/src/client/js/otp/core/Map.js
@@ -100,8 +100,7 @@ otp.core.Map = otp.Class({
             data: { routerId : otp.config.routerId },            
             dataType: 'JSON',
             
-            success: 
-            function(data) {				
+            success: function(data) {				
 				otp.config.mapBoundary = new L.latLngBounds(new L.latLng(data.lowerLeftLatitude, data.lowerLeftLongitude), new L.latLng(data.upperRightLatitude, data.upperRightLongitude));
 		
 				if(otp.config.geoLocation){
@@ -121,7 +120,7 @@ otp.core.Map = otp.Class({
 				if (e.accuracy >= 22000) {
 					console.log("Accuracy beyond threshold; recentering on USF.");
 					e.latlng = otp.config.initLatLng;
-					this.queueView(e.latlng, 15);
+					this.queueView(e.latlng, otp.config.initZoom);
 					return; // dont bother adding a marker 
 				}
 				
@@ -129,7 +128,7 @@ otp.core.Map = otp.Class({
 				if ( ! otp.config.mapBoundary.contains(e.latlng)) {
 					console.log("Geolocation is outside of map boundaries; recentering on USF.");
 					e.latlng = otp.config.initLatLng;
-					this.queueView(e.latlng, 15);
+					this.queueView(e.latlng, otp.config.initZoom);
 					return; // and don't add a marker on first load
 				}				
 				
@@ -149,7 +148,7 @@ otp.core.Map = otp.Class({
             	this.addLayer(accCircle);
             	//if statement will make it so the map only zooms on the first function call
             	if (count == 1){
-            	  this.queueView(e.latlng, 17);
+            	  this.queueView(e.latlng, otp.config.gpsZoom);
             	};
             	//following removes the last set of map markers on the last function call
             	this.removeLayer(tempM);


### PR DESCRIPTION
fixes #65 : The map now is center on USF campus when a user does not share his location. 
Value of the attribute "zoomToFitResults" set at "true".
fixes #45 : The map now center on the trip planned by the user. 
Modification of the center of the map by modifying the attribute "initLatLng".
Deletion of the code forcing to fit the boundary which caused the zoomed out view.
fixes #69 : The user cannot zoom too much.
Change the "minZoom" attribute to 9 because 8 cause the map to be all gray and necessitate multiple zoom out to be restored.
