### PR TITLE
Fixes #139. Change the title from MoBullity to USF Maps.

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -6,7 +6,7 @@
 <!--[if (gt IE 9)|!(IE)]><!--> <html dir="ltr" lang="en-US"> <!--<![endif]-->
 
 <head>
-<title>OpenTripPlanner</title>
+<title>USF Maps</title>
 
 <!--  Favicon for the website -->
 <link rel="shortcut icon" href="/images/favicon.ico"/>

--- a/src/client/js/otp/config.js
+++ b/src/client/js/otp/config.js
@@ -85,7 +85,7 @@ otp.config = {
      * Site name / description / branding display options
      */
 
-    siteName            : "MoBullity",
+    siteName            : "USF Maps",
     siteDescription     : "An OpenTripPlanner deployment for USF.",
     logoGraphic         : 'images/usf-h-gold.png',
     // bikeshareName    : "",


### PR DESCRIPTION
I changed the title [here](https://github.com/CUTR-at-USF/usf-mobullity/blob/mobullityrebase/src/client/js/otp/config.js#L88) and [here](https://github.com/CUTR-at-USF/usf-mobullity/blob/mobullityrebase/src/client/index.html#L9).

Since we are in here I was wondering if the the description of the website is good or if @barbeau would like to change it.

The website description is "An OpenTripPlanner deployment for USF." and can be found [here](https://github.com/CUTR-at-USF/usf-mobullity/blob/mobullityrebase/src/client/js/otp/config.js#L89).
I'm not sure where it appear for the user though.
