### PR TITLE
Fix #145 - widget color on the welcome popup to be black instead of white

### DIFF
--- a/src/client/js/otp/widgets/WidgetManager.js
+++ b/src/client/js/otp/widgets/WidgetManager.js
@@ -1,0 +1,48 @@
+/* This program is free software: you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public License
+   as published by the Free Software Foundation, either version 3 of
+   the License, or (at your option) any later version.
+   
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+   
+   You should have received a copy of the GNU General Public License
+   along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+*/
+
+otp.namespace("otp.widgets");
+
+otp.widgets.WidgetManager = otp.Class({
+
+    widgets     : null,
+
+    initialize : function() {
+        this.widgets = []; 
+    },
+    
+    addWidget : function(widget) {
+        this.widgets.push(widget);
+    },
+    
+    getFrontZIndex : function() {
+        var maxZIndex = 0;
+        for(var i=0; i<this.widgets.length; i++) {
+            var zIndex = this.widgets[i].$().css('zIndex');
+            maxZIndex = Math.max(maxZIndex, zIndex);
+        }
+        return maxZIndex;
+    },
+
+    getBackZIndex : function() {
+        var minZIndex = 10000;
+        for(var i=0; i<this.widgets.length; i++) {
+            var zIndex = this.widgets[i].$().css('zIndex');
+            minZIndex = Math.min(minZIndex, zIndex);
+        }
+        return minZIndex;
+    },
+    
+});
+

--- a/src/client/style.css
+++ b/src/client/style.css
@@ -564,6 +564,11 @@ hr.menu_separator{
     z-index: 9001;
 } 
 
+/* Specifically override the new white widget icons here because the background is also white */
+#otp-WelcomeWidget .otp-widget-header-button { 
+    color: black;
+}
+
 /* Change the looks of the widget windows */
 
 .otp-defaultInfoWidget {


### PR DESCRIPTION
Also, PR#108 deleted the WidgetManager.js ... I didn't catch it before, but when I tried to test this CSS I had issues because this was missing, so readding it.

The reason why it wasn't an issue on dev or production is because they already had the file in a temporary store and used it even though the jar no longer had it.
