### PR TITLE
Improve geolocation denied error message - fixes #148

### DIFF
--- a/src/client/js/lib/leaflet/L.Control.Locate.js
+++ b/src/client/js/lib/leaflet/L.Control.Locate.js
@@ -69,7 +69,15 @@ You can find the project at: https://github.com/domoritz/leaflet-locatecontrol
             onLocationError: function(err) {
                 // this event is called in case of any location error
                 // that is not a time out error.
-                alert(err.message);
+
+                switch (err.code) {
+                case 1: /* The HTML5 standard specifies err.PERMISSION_DENIED, leaflet does not pass this through */
+                    alert("To see your real-time position on the map, please allow USF Maps to access your location");
+                    break;
+                default:
+                    alert(err.message);
+                }
+
             },
             onLocationOutsideMapBounds: function(control) {
                 // this event is repeatedly called when the location changes


### PR DESCRIPTION
Added a different message to explain that the request to access GPS was denied, while maintaining any other messages that might happen (timeout, etc) as specified at:

http://www.w3schools.com/html/html5_geolocation.asp or https://www.w3.org/TR/geolocation-API/#position_error_interface
