### PR TITLE
Quick fix. Changed the color of the lines in the layer widget 

### DIFF
--- a/src/client/style.css
+++ b/src/client/style.css
@@ -697,7 +697,7 @@ div#otp-planner-optionsWidget-scollPanel {
 	padding:10px;
 }
 
-.otp-layerView-inner fieldset { border-top:1px solid #000; }
+.otp-layerView-inner fieldset { border-top:1px solid gray; }
 .otp-layerView-inner fieldset legend { text-align:center; }
 
 .layerView .bus, .layerView .bikes, .layerView .parking { padding: 5px; text-align:left; }


### PR DESCRIPTION
As discussed in the previous meeting the lines inside of the layer widget are gray (Previously it was black).

Note:The gray of this line is the same than the gray used for the broder.

Screenshot: 
![image](https://cloud.githubusercontent.com/assets/1370401/13081840/4ba5041c-d49c-11e5-96b3-d5ee3e5d0f05.png)
