### PR TITLE
Remove old hidden nav-menu preventing click events to widgets

### DIFF
--- a/src/client/js/otp/config.js
+++ b/src/client/js/otp/config.js
@@ -103,6 +103,8 @@ otp.config = {
     showBikeStations	: true,
     showBikeLanes		: true,
 
+    showWidgetMenu      : false, /* The old-style drop down menu with all active widgets ... 'gears icon' */
+
     /**
      * Modules: a list of the client modules to be loaded at startup. Expressed
      * as an array of objects, where each object has the following fields:

--- a/src/client/js/otp/core/Webapp.js
+++ b/src/client/js/otp/core/Webapp.js
@@ -114,7 +114,7 @@ otp.core.Webapp = otp.Class({
         this.widgetManager = new otp.widgets.WidgetManager();
         
         // create the info widgets and links along header bar
-        if(otp.config.infoWidgets !== undefined && otp.config.infoWidgets.length > 0) {
+        if(otp.config.showWidgetMenu && otp.config.infoWidgets !== undefined && otp.config.infoWidgets.length > 0) {
             var nav = $('<nav id="main-menu" role="article">').appendTo('#branding');
             var ul = $('<ul>').appendTo(nav);
 


### PR DESCRIPTION
Add config option to disable the old-style nav menu that was hidden above the "X" icons in the map widgets preventing anyone from clicking them

Fixes #191
