### PR TITLE
Ignore right-clicks in parent click event so menu wont immediately

### DIFF
--- a/src/client/js/otp/core/ContextMenu.js
+++ b/src/client/js/otp/core/ContextMenu.js
@@ -25,14 +25,19 @@ otp.core.ContextMenu =
         
         var this_ = this;
         
-        this.parent = parent;
+        this.parent = parent; /* Widget.js mainDiv */
+        parent.contextMenuOpened = false;
         
         parent.on('contextmenu', function(event) {
             if(event.preventDefault) event.preventDefault();
+
+            this_.parent.contextMenuOpened = true; 
             this_.menu.show();
             this_.menu.offset(this_.getOffset(event)).appendTo("body");
 
             if(menuClicked) menuClicked.call(this, event);
+
+            return false;
         });
     },
 });    

--- a/src/client/js/otp/core/PopupMenu.js
+++ b/src/client/js/otp/core/PopupMenu.js
@@ -27,6 +27,13 @@ otp.core.PopupMenu = otp.Class({
         this.menu = $('<div class="otp-popupMenu"></div>');
         
         $(document).bind("click", function(event) {
+            // ignore right clicks - we handle contextmenu in ContextMenu.js
+            if (event.which == 3) { 
+                this_.contextMenuOpened = false;
+                event.stopPropagation();
+                return;
+            }
+
             if(this_.suppressHide) {
                 this_.suppressHide = false;
                 return;


### PR DESCRIPTION
hide in firefox which fires both events - fixes #192
