### PR TITLE
Fix bike selectors on tripoptions form

### DIFF
--- a/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
@@ -551,14 +551,14 @@ otp.widgets.tripoptions.ModeSelector =
         $(html).appendTo(this.$());
 
 	// Add Bicycle Safety
-	html = "<div class='notDraggable',> Bicycle Safety: ";
+	html = "<div style='display:none' class='bike_safety notDraggable'> Prefer Bike Lanes: ";
 	html += "<select id='bike_safety'>";
-	html += "<option value=''>No Preference</option>";
-	html += "<option value='1'>Prefer Lanes</option>";
+	html += "<option value=''>No</option>";
+	html += "<option value='1'>Yes</option>";
 	html += "</select>";
 	html += "</div>";
        	$(html).appendTo(this.$());
- 
+
         //this.setContent(content);
         
     },
@@ -570,6 +570,10 @@ otp.widgets.tripoptions.ModeSelector =
                 mode : _.keys(this_.modes)[this.selectedIndex],
             });
             this_.refreshModeControls();
+
+            if ($(this).val().indexOf("Bicycle") >= 0) $('.bike_safety').show();
+            else $('.bike_safety').hide();
+
         });
 
 	$('#bike_safety').change(function() {
@@ -753,7 +757,7 @@ otp.widgets.tripoptions.MaxBikeSelector =
     },
     
     isApplicableForMode : function(mode) {
-        return otp.util.Itin.includesTransit(mode) && otp.util.Itin.includesBicycle(mode);
+        return otp.util.Itin.includesAnyBicycle(mode);
     },
 
 });


### PR DESCRIPTION
Make max bike distance selector not care about TRANSIT mode, also
manually hide the bike lane/safety dropdown and only show when
the mode has 'Bicycle' in it - Fixes #211

It should be noted that although this works, the bike lane dropdown
doesn't follow the same JS pattern as the rest - and could be cleaned up
for later.
