### PR TITLE
Fix #231

### DIFF
--- a/src/client/js/otp/layers/BikeStationsLayer.js
+++ b/src/client/js/otp/layers/BikeStationsLayer.js
@@ -39,7 +39,8 @@ otp.layers.BikeStationsLayer =
 
 			// Refresh data every 5 seconds
                         setInterval($.proxy(this.liveMap,this),5000);
-			
+		
+            this.firstloaded = true;	
 			this.liveMap();
 		},
 
@@ -56,6 +57,10 @@ otp.layers.BikeStationsLayer =
 
 		liveMap : function() {
 			this_ = this;
+
+            if (!this.visible && !this.firstloaded) return;
+            this.firstloaded = false;
+
 			var url = otp.config.hostname + '/' + "otp/routers/default/bike_rental";
 			$.ajax(url, {
 				type: 'GET',

--- a/src/client/js/otp/layers/BusPositionsLayer.js
+++ b/src/client/js/otp/layers/BusPositionsLayer.js
@@ -382,7 +382,7 @@ otp.layers.BusPositionsLayer =
 
 				// XXX use defined agency and detect the tripid (01) ?
 			        $.ajax({
-                		url: '/otp/routers/default/index/patterns/USF Bull Runner_'+route+'_01/geometries',
+                		url: otp.config.hostname + '/otp/routers/default/index/patterns/USF Bull Runner_'+route+'_01/geometries',
                 		this_: this,
 				rte: route,
 		                dataType: 'json',
@@ -400,7 +400,11 @@ otp.layers.BusPositionsLayer =
 		refresh : function() {
 			this.clearLayers();
 			var lmap = this.module.webapp.map.lmap;
-			if(lmap.getZoom() >= this.minimumZoomForStops) {
+            var busRouteVisible = this.visible.indexOf('A') != -1 || this.visible.indexOf('B') != -1 
+                                    || this.visible.indexOf('C') != -1 || this.visible.indexOf('D') != -1
+                                    || this.visible.indexOf('E') != -1 || this.visible.indexOf('F') != -1;
+
+			if(lmap.getZoom() >= this.minimumZoomForStops && busRouteVisible) {
 				this.liveMap(); //need to get updated vehicle positions
 				this.setRoutes(); //need to reset routes display on the map
 			}


### PR DESCRIPTION
Make BusPositions and BikeStations layers only poll for updates via ajax if their respective layers are visible.

Also, add missing otp.config.hostname to initial busposition geometry call on load.
