### PR TITLE
fix #207. Modification of the behavior and size of the autocomplete l…

### DIFF
--- a/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
@@ -291,7 +291,12 @@ otp.widgets.tripoptions.LocationsSelector =
                setterFunction.call(this.module.tripWidget.module, latlng, false, result.description);
                this.module.tripWidget.inputChanged();
        }.bind(input[0]);
-
+       
+       /* hide the autocomplete list when the user click somewhere */
+       $(document).bind('click', function (event) {
+            $(".ui-autocomplete").hide();            
+       });
+       
        input.autocomplete({
              autoFocus: true,
              source: function(request, response) {

--- a/src/client/js/otp/widgets/tripoptions/tripoptions-style.css
+++ b/src/client/js/otp/widgets/tripoptions/tripoptions-style.css
@@ -6,6 +6,26 @@
 
 /* Locations Picker */
 
+
+.ui-autocomplete { 
+    /* This z-index allow the autocomplete widget to be above the minimized tabs */
+    z-index:10001 !important;
+    overflow-y: auto;
+}
+@media only screen and (min-width: 768px){ 
+    .ui-autocomplete {
+        max-height: 75%;
+        min-width: 560px;
+    }
+}
+
+@media only screen and (max-width: 768px){ 
+    .ui-autocomplete {
+        max-height: 70%;
+        max-width: 70%;
+    }
+}
+
 .otp-tripOptions-loc-input {
     width:100%;
     border-radius: 0px;


### PR DESCRIPTION
…ist for the start and end input fields.

The autocomplete list changed in size:
![image](https://cloud.githubusercontent.com/assets/1370401/14022084/9c5ab4c6-f1b4-11e5-80ae-4fc7e211209b.png)
![image](https://cloud.githubusercontent.com/assets/1370401/14022091/a55a4514-f1b4-11e5-9e37-a09e79fea65e.png)

It is also above the minimized tab at the bottom which fixes #207 
Illustration of the problem:
![image](https://cloud.githubusercontent.com/assets/1370401/14022166/092a0ade-f1b5-11e5-8f15-0f72a090e638.png)

The behavior changed: when a user click somewhere else that an element of the list the list is hidden.
this avoid having a floating list on the map like in the following screenshot:
![image](https://cloud.githubusercontent.com/assets/1370401/14022178/1608e46e-f1b5-11e5-8dbd-531d980481ae.png)
