### PR TITLE
Add Points of Interest backend API: /otp/routers/default/pois

### DIFF
--- a/src/client/images/marker-blue.svg
+++ b/src/client/images/marker-blue.svg
@@ -15,7 +15,7 @@
    id="svg3449"
    version="1.1"
    inkscape:version="0.91 r"
-   sodipodi:docname="marker-carshare.svg">
+   sodipodi:docname="marker-bike.svg">
   <defs
      id="defs3451" />
   <sodipodi:namedview
@@ -26,16 +26,16 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="0.35"
-     inkscape:cx="116.42857"
-     inkscape:cy="280"
+     inkscape:cx="-112.14286"
+     inkscape:cy="520"
      inkscape:document-units="px"
-     inkscape:current-layer="svg3449"
+     inkscape:current-layer="layer1"
      showgrid="false"
      units="mm"
-     inkscape:window-width="1901"
-     inkscape:window-height="717"
+     inkscape:window-width="1366"
+     inkscape:window-height="716"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="0"
      inkscape:window-maximized="1" />
   <metadata
      id="metadata3454">
@@ -45,7 +45,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -53,34 +53,24 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(0,-583.92909)"
-     style="display:inline">
+     transform="translate(0,-583.92909)">
     <path
        inkscape:connector-curvature="0"
        id="path4565"
-       d="m 177.71652,605.67396 c -86.416646,0 -156.478976,70.04847 -156.478976,156.47437 0,86.41666 156.478976,271.63347 156.478976,271.63347 0,0 156.479,-185.21219 156.479,-271.63347 0,-86.42128 -70.05309,-156.47437 -156.479,-156.47437 z"
+       d="m 180.11193,605.67396 c -86.416656,0 -156.478985,70.04847 -156.478985,156.47437 0,86.41666 156.478985,271.63347 156.478985,271.63347 0,0 156.47899,-185.21219 156.47899,-271.63347 0,-86.42128 -70.05309,-156.47437 -156.47899,-156.47437 z"
        sodipodi:nodetypes="sscss"
-       style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-opacity:1" />
-  </g>
-  <g
-     id="icon"
-     viewBox="0 0 24 24"
-     transform="matrix(9.3928576,0,0,9.3928576,65.00224,52.035713)"
-     style="fill:#ffffff">
-    <path
-       d="m 5,11 1.5,-4.5 11,0 1.5,4.5 m -1.5,5 A 1.5,1.5 0 0 1 16,14.5 1.5,1.5 0 0 1 17.5,13 1.5,1.5 0 0 1 19,14.5 1.5,1.5 0 0 1 17.5,16 m -11,0 A 1.5,1.5 0 0 1 5,14.5 1.5,1.5 0 0 1 6.5,13 1.5,1.5 0 0 1 8,14.5 1.5,1.5 0 0 1 6.5,16 M 18.92,6 C 18.72,5.42 18.16,5 17.5,5 L 6.5,5 C 5.84,5 5.28,5.42 5.08,6 L 3,12 3,20 a 1,1 0 0 0 1,1 l 1,0 a 1,1 0 0 0 1,-1 l 0,-1 12,0 0,1 a 1,1 0 0 0 1,1 l 1,0 a 1,1 0 0 0 1,-1 l 0,-8 -2.08,-6 z"
-       id="path9"
-       inkscape:connector-curvature="0" />
+       style="fill:#10abe9;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-opacity:1" />
   </g>
   <g
      inkscape:groupmode="layer"
      id="layer2"
      inkscape:label="Layer 2"
-     style="display:inline">
+     sodipodi:insensitive="true">
     <path
+       transform="translate(0,-583.92909)"
        inkscape:connector-curvature="0"
        id="path4565-5"
-       d="m 177.71652,10.9831 c -92.196789,0 -166.945508,74.734 -166.945508,166.94069 0,92.19699 166.945508,289.80262 166.945508,289.80262 0,0 166.94553,-197.60084 166.94553,-289.80262 0,-92.20178 -74.73871,-166.94069 -166.94553,-166.94069 z"
+       d="m 180.21429,594.91219 c -92.19679,0 -166.945509,74.734 -166.945509,166.94069 0,92.19699 166.945509,289.80262 166.945509,289.80262 0,0 166.94553,-197.60084 166.94553,-289.80262 0,-92.20178 -74.73871,-166.94069 -166.94553,-166.94069 z"
        sodipodi:nodetypes="sscss"
        style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.06688809;stroke-opacity:1" />
   </g>

--- a/src/client/images/marker-green.svg
+++ b/src/client/images/marker-green.svg
@@ -15,7 +15,7 @@
    id="svg3449"
    version="1.1"
    inkscape:version="0.91 r"
-   sodipodi:docname="marker-carshare.svg">
+   sodipodi:docname="marker-bike.svg">
   <defs
      id="defs3451" />
   <sodipodi:namedview
@@ -26,16 +26,16 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="0.35"
-     inkscape:cx="116.42857"
-     inkscape:cy="280"
+     inkscape:cx="-112.14286"
+     inkscape:cy="520"
      inkscape:document-units="px"
-     inkscape:current-layer="svg3449"
+     inkscape:current-layer="layer1"
      showgrid="false"
      units="mm"
-     inkscape:window-width="1901"
-     inkscape:window-height="717"
+     inkscape:window-width="1366"
+     inkscape:window-height="716"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="0"
      inkscape:window-maximized="1" />
   <metadata
      id="metadata3454">
@@ -45,7 +45,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -53,34 +53,24 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(0,-583.92909)"
-     style="display:inline">
+     transform="translate(0,-583.92909)">
     <path
        inkscape:connector-curvature="0"
        id="path4565"
-       d="m 177.71652,605.67396 c -86.416646,0 -156.478976,70.04847 -156.478976,156.47437 0,86.41666 156.478976,271.63347 156.478976,271.63347 0,0 156.479,-185.21219 156.479,-271.63347 0,-86.42128 -70.05309,-156.47437 -156.479,-156.47437 z"
+       d="m 180.11193,605.67396 c -86.416656,0 -156.478985,70.04847 -156.478985,156.47437 0,86.41666 156.478985,271.63347 156.478985,271.63347 0,0 156.47899,-185.21219 156.47899,-271.63347 0,-86.42128 -70.05309,-156.47437 -156.47899,-156.47437 z"
        sodipodi:nodetypes="sscss"
-       style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-opacity:1" />
-  </g>
-  <g
-     id="icon"
-     viewBox="0 0 24 24"
-     transform="matrix(9.3928576,0,0,9.3928576,65.00224,52.035713)"
-     style="fill:#ffffff">
-    <path
-       d="m 5,11 1.5,-4.5 11,0 1.5,4.5 m -1.5,5 A 1.5,1.5 0 0 1 16,14.5 1.5,1.5 0 0 1 17.5,13 1.5,1.5 0 0 1 19,14.5 1.5,1.5 0 0 1 17.5,16 m -11,0 A 1.5,1.5 0 0 1 5,14.5 1.5,1.5 0 0 1 6.5,13 1.5,1.5 0 0 1 8,14.5 1.5,1.5 0 0 1 6.5,16 M 18.92,6 C 18.72,5.42 18.16,5 17.5,5 L 6.5,5 C 5.84,5 5.28,5.42 5.08,6 L 3,12 3,20 a 1,1 0 0 0 1,1 l 1,0 a 1,1 0 0 0 1,-1 l 0,-1 12,0 0,1 a 1,1 0 0 0 1,1 l 1,0 a 1,1 0 0 0 1,-1 l 0,-8 -2.08,-6 z"
-       id="path9"
-       inkscape:connector-curvature="0" />
+       style="fill:#006747;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-opacity:1" />
   </g>
   <g
      inkscape:groupmode="layer"
      id="layer2"
      inkscape:label="Layer 2"
-     style="display:inline">
+     sodipodi:insensitive="true">
     <path
+       transform="translate(0,-583.92909)"
        inkscape:connector-curvature="0"
        id="path4565-5"
-       d="m 177.71652,10.9831 c -92.196789,0 -166.945508,74.734 -166.945508,166.94069 0,92.19699 166.945508,289.80262 166.945508,289.80262 0,0 166.94553,-197.60084 166.94553,-289.80262 0,-92.20178 -74.73871,-166.94069 -166.94553,-166.94069 z"
+       d="m 180.21429,594.91219 c -92.19679,0 -166.945509,74.734 -166.945509,166.94069 0,92.19699 166.945509,289.80262 166.945509,289.80262 0,0 166.94553,-197.60084 166.94553,-289.80262 0,-92.20178 -74.73871,-166.94069 -166.94553,-166.94069 z"
        sodipodi:nodetypes="sscss"
        style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.06688809;stroke-opacity:1" />
   </g>

--- a/src/client/images/marker-red.svg
+++ b/src/client/images/marker-red.svg
@@ -15,7 +15,7 @@
    id="svg3449"
    version="1.1"
    inkscape:version="0.91 r"
-   sodipodi:docname="marker-carshare.svg">
+   sodipodi:docname="marker-bike.svg">
   <defs
      id="defs3451" />
   <sodipodi:namedview
@@ -26,16 +26,16 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="0.35"
-     inkscape:cx="116.42857"
-     inkscape:cy="280"
+     inkscape:cx="-112.14286"
+     inkscape:cy="520"
      inkscape:document-units="px"
-     inkscape:current-layer="svg3449"
+     inkscape:current-layer="layer1"
      showgrid="false"
      units="mm"
-     inkscape:window-width="1901"
-     inkscape:window-height="717"
+     inkscape:window-width="1366"
+     inkscape:window-height="716"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="0"
      inkscape:window-maximized="1" />
   <metadata
      id="metadata3454">
@@ -45,7 +45,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -53,34 +53,24 @@
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
      id="layer1"
-     transform="translate(0,-583.92909)"
-     style="display:inline">
+     transform="translate(0,-583.92909)">
     <path
        inkscape:connector-curvature="0"
        id="path4565"
-       d="m 177.71652,605.67396 c -86.416646,0 -156.478976,70.04847 -156.478976,156.47437 0,86.41666 156.478976,271.63347 156.478976,271.63347 0,0 156.479,-185.21219 156.479,-271.63347 0,-86.42128 -70.05309,-156.47437 -156.479,-156.47437 z"
+       d="m 180.11193,605.67396 c -86.416656,0 -156.478985,70.04847 -156.478985,156.47437 0,86.41666 156.478985,271.63347 156.478985,271.63347 0,0 156.47899,-185.21219 156.47899,-271.63347 0,-86.42128 -70.05309,-156.47437 -156.47899,-156.47437 z"
        sodipodi:nodetypes="sscss"
        style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-opacity:1" />
-  </g>
-  <g
-     id="icon"
-     viewBox="0 0 24 24"
-     transform="matrix(9.3928576,0,0,9.3928576,65.00224,52.035713)"
-     style="fill:#ffffff">
-    <path
-       d="m 5,11 1.5,-4.5 11,0 1.5,4.5 m -1.5,5 A 1.5,1.5 0 0 1 16,14.5 1.5,1.5 0 0 1 17.5,13 1.5,1.5 0 0 1 19,14.5 1.5,1.5 0 0 1 17.5,16 m -11,0 A 1.5,1.5 0 0 1 5,14.5 1.5,1.5 0 0 1 6.5,13 1.5,1.5 0 0 1 8,14.5 1.5,1.5 0 0 1 6.5,16 M 18.92,6 C 18.72,5.42 18.16,5 17.5,5 L 6.5,5 C 5.84,5 5.28,5.42 5.08,6 L 3,12 3,20 a 1,1 0 0 0 1,1 l 1,0 a 1,1 0 0 0 1,-1 l 0,-1 12,0 0,1 a 1,1 0 0 0 1,1 l 1,0 a 1,1 0 0 0 1,-1 l 0,-8 -2.08,-6 z"
-       id="path9"
-       inkscape:connector-curvature="0" />
   </g>
   <g
      inkscape:groupmode="layer"
      id="layer2"
      inkscape:label="Layer 2"
-     style="display:inline">
+     sodipodi:insensitive="true">
     <path
+       transform="translate(0,-583.92909)"
        inkscape:connector-curvature="0"
        id="path4565-5"
-       d="m 177.71652,10.9831 c -92.196789,0 -166.945508,74.734 -166.945508,166.94069 0,92.19699 166.945508,289.80262 166.945508,289.80262 0,0 166.94553,-197.60084 166.94553,-289.80262 0,-92.20178 -74.73871,-166.94069 -166.94553,-166.94069 z"
+       d="m 180.21429,594.91219 c -92.19679,0 -166.945509,74.734 -166.945509,166.94069 0,92.19699 166.945509,289.80262 166.945509,289.80262 0,0 166.94553,-197.60084 166.94553,-289.80262 0,-92.20178 -74.73871,-166.94069 -166.94553,-166.94069 z"
        sodipodi:nodetypes="sscss"
        style="fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.06688809;stroke-opacity:1" />
   </g>

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -18,9 +18,6 @@
 <!-- Google WebFonts -->
 <link href='http://fonts.googleapis.com/css?family=Dancing+Script:700' rel='stylesheet' type='text/css'>
 
-<link rel="stylesheet" href="//cdn.materialdesignicons.com/1.4.57/css/materialdesignicons.min.css">
-
-
 <!-- jquery -->
 <script src="js/lib/jquery/jquery-1.9.1.js"></script>
 
@@ -49,6 +46,7 @@
 <link rel="stylesheet" href="https://storage.googleapis.com/code.getmdl.io/1.0.5/material.indigo-pink.min.css">
 <script src="https://storage.googleapis.com/code.getmdl.io/1.0.5/material.min.js"></script>
 <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+<link rel="stylesheet" href="//cdn.materialdesignicons.com/1.4.57/css/materialdesignicons.min.css">
 
 <!-- json support -->
 <script src="js/lib/json2.js"></script>

--- a/src/client/js/otp/config.js
+++ b/src/client/js/otp/config.js
@@ -6,6 +6,39 @@ function sendfeedback() {
     return content;
 }
 
+/* Define layers icons */
+bluephone_icon =  L.icon({angle:0, iconUrl: '/images/marker-bluephone.svg', iconSize: new L.Point(30,60), iconAnchor: new L.Point(15,50) });
+carshare_icon = L.icon({angle:0, iconUrl: '/images/marker-carshare.svg', iconSize: new L.Point(30,60), iconAnchor: new L.Point(15,55) });
+
+L.layersIcon = L.DivIcon.extend({
+    options: {
+        iconSize: [35, 45],
+        iconAnchor: [18, 45],
+        icon: '',
+        color: 'blue',
+    },
+
+    initialize: function(opts) {
+        options = L.Util.setOptions(this, opts);
+    },
+
+    createIcon: function() {
+        var div = document.createElement("div");
+        div.innerHTML = "<i class='"+this.options.icon+"'></i>";
+
+        div.style = "background-size: "+this.options.iconSize[0]+"px "+this.options.iconSize[1]+"px";
+        this._setIconStyles(div, 'icon');
+
+        div.className = "layersIcon layersIcon-" + this.options.color;
+
+        var outer = document.createElement('div');
+        outer.appendChild(div);
+
+        return outer;
+    },
+
+});
+
 otp.config = {
     debug: false,
     locale: otp.locale.English,
@@ -202,8 +235,15 @@ otp.config = {
 
     ],
 
+    layersWidget: [
+        { name: 'blue_phones', target: '#bluephone', icon: bluephone_icon, type: 'static', title: 'Blue Light <br/> Emergency Phones', popup: "<b>Use Blue Light Phones to contact Police</b><br><a target='_blank' href='http://www.usf.edu/administrative-services/emergency-management/resources/campus-safety.aspx'>More about campus safety</a>", locations: [[28.0614434,-82.4078041], [28.0555655,-82.4084315], [28.0641975,-82.4185115], [28.0651509,-82.4183224], [28.0652518,-82.4124851], [28.0582386,-82.4225447], [28.0618976,-82.4141717], [28.0615615,-82.4137318], [28.0599592,-82.4069672], [28.0610142,-82.4149218], [28.0591974,-82.4130281], [28.0599166,-82.4078553], [28.0611144,-82.4187288], [28.0630924,-82.4229122], [28.0688995,-82.4130541], [28.0631877,-82.4136464], [28.0632019,-82.4118091], [28.0662717,-82.4191208], [28.0655687,-82.4105538], [28.0641913,-82.4141936], [28.0658575,-82.4130831], [28.0641581,-82.4127264], [28.0652658,-82.4099050], [28.0675588,-82.4256194], [28.0661246,-82.4206762], [28.0660985,-82.4245251], [28.0590405,-82.4201638], [28.0591163,-82.4192972], [28.0582144,-82.4185594], [28.0626681,-82.4144783], [28.0598752,-82.4193438], [28.0628149,-82.4173562], [28.0599651,-82.4176474], [28.0651523,-82.4234651], [28.0603440,-82.4142791], [28.0679737,-82.4155233], [28.0680589,-82.4133400], [28.0663549,-82.4050145], [28.0680589,-82.4053470], [28.0655857,-82.4073694], [28.0666507,-82.4073238], [28.0658389,-82.4087159], [28.0654484,-82.4090968], [28.0665276,-82.4081660], [28.0649845,-82.4113340], [28.0649951,-82.4105895], [28.0669113,-82.4190557], [28.0666677,-82.4197853], [28.0618552,-82.4209247], [28.0678908,-82.4223870], [28.0584771,-82.4084789], [28.0652073,-82.4086336], [28.0661801,-82.4114123], [28.0683646,-82.4098433], [28.0665417,-82.4087582], [28.0665890,-82.4107541], [28.0619428,-82.4029260], [28.0598972,-82.4029098], [28.0668664,-82.4089528], [28.0661730,-82.4098889], [28.0676942,-82.4114296], [28.0685342,-82.4117649], [28.0675338,-82.4091030], [28.0684183,-82.4072753], [28.0600344,-82.4089220], [28.0600490,-82.4100958], [28.0582358,-82.4121799], [28.0591210,-82.4116568], [28.0662335,-82.4029024], [28.0589559,-82.4179827], [28.0596162,-82.4209013], [28.0594457,-82.4185302], [28.0601510,-82.4184505], [28.0630128,-82.4097381], [28.0629156,-82.4104837], [28.0605726,-82.4120424], [28.0610623,-82.4100948], [28.0620187,-82.4113286], [28.0628495,-82.4252844], [28.0567379,-82.4088338], [28.0611240,-82.4071658], [28.0582317,-82.4201016], [28.0617204,-82.4174919], [28.0678858,-82.4176509], [28.0581327,-82.4066318], [28.0626081,-82.4180444], [28.0580570,-82.4029953], [28.0581694,-82.4106393], [28.0583376,-82.4052632], [28.0590952,-82.4174743], [28.0582401,-82.4171404], [28.0591035,-82.4167762]], color: 'blue' },
+        { name: 'car_share', target: '#carshare', icon: carshare_icon, type: 'static', title: 'Enterprise CarShare', popup: "<a target='_blank' href='https://www.enterprisecarshare.com/us/en/programs/university/usf.html'>Reserve a car</a>", locations: [[28.059951, -82.417575], [28.064287, -82.412130]], color: 'red' },
 
-
+        { name: 'bike_repair', target: '#bikerepair', icon: new L.layersIcon({icon: 'mdi mdi-wrench', color: 'green'}), type: 'poi', search: 'bicycle_repair_station', popupTemplate: 'bikeRepair-template', color: '#006747' },
+        { name: 'car_charging', target: '#carcharging', icon: new L.layersIcon({icon: 'mdi mdi-battery-charging', color: 'red'}), type: 'poi', search: 'charging_station', popupTemplate: 'carCharging-template', color: "red" },
+        { name: 'parking', target: '#parkinglots', icon: new L.layersIcon({icon: 'mdi mdi-parking', color: 'red'}), type: 'poi', search: 'amenity:parking', popupTemplate: 'parkingLots-template', condition: "permits", color: "red" },
+    ],
+ 
 
     /**
      * Formats to use for date and time displays, expressed as ISO-8601 strings.

--- a/src/client/js/otp/layers/BikeLanes.js
+++ b/src/client/js/otp/layers/BikeLanes.js
@@ -37,7 +37,7 @@ otp.layers.BikeLanesLayer =
         this.module.webapp.map.lmap.on('dragend zoomend', $.proxy(this.refresh, this));
         
         $.ajax({
-        	url: '/otp/routers/default/bike_lanes', 
+        	url: otp.config.hostname + "/" + otp.config.restService + '/bike_lanes', 
         	webapp: this.module.webapp,
         	this_: this,
         	dataType: 'json',
@@ -63,8 +63,8 @@ otp.layers.BikeLanesLayer =
         	for (p in this.bikeLanes) {
 
 			// For first four segments of bounding box
-			if (i < 4) opts = {color: 'red', dashArray: '5, 5'};
-			else opts = {color: 'red'};
+			if (i < 4) opts = {color: '#006747', dashArray: '5, 5'};
+			else opts = {color: '#006747'};
 
     			ret=L.polyline(this.bikeLanes[p], opts);    			
 

--- a/src/client/js/otp/layers/BusPositionsLayer.js
+++ b/src/client/js/otp/layers/BusPositionsLayer.js
@@ -848,7 +848,7 @@ otp.layers.BusPositionsLayer =
 
 			if (this.visible.indexOf('D') != -1) this.drawRoutePolyline(this.route_polylines['D'], {color: '#F70505'} );
 
-			if (this.visible.indexOf('E') != -1) this.drawRoutePolyline(this.route_polylines['E'], {color: '#D4BA13'} );
+			if (this.visible.indexOf('E') != -1) this.drawRoutePolyline(this.route_polylines['E'], {color: '#bca510'} );
 
 			if (this.visible.indexOf('F') != -1) this.drawRoutePolyline(this.route_polylines['F'], {color: '#8F6A51'} );
 

--- a/src/client/js/otp/layers/layers-templates.html
+++ b/src/client/js/otp/layers/layers-templates.html
@@ -92,15 +92,6 @@
 </div>
 </fieldset>
 
-<!--
-<fieldset>
-<legend>Live Bus Positions</legend>
-<div class=bus>
-<input type=checkbox checked id="bus_positions" /> <label for=bus_positions>USF</label> <br>
-</div>
-</fieldset>
--->
-
 <fieldset>
 <legend>USF Bike Info</legend>
 <div class=bikes>
@@ -108,6 +99,12 @@
 <div id="bike_stations" class="route-menu-item selected">
 <div class="box"></div><div class="color"></div>
 <div class="name">Share-A-Bull Bikes</div>
+</div>
+<div style="clear:left;"></div>
+
+<div id="bikerepair" class="route-menu-item selected">
+<div class="box"></div><div class="color"></div>
+<div class="name">Bike Repair Stations</div>
 </div>
 <div style="clear:left;"></div>
 
@@ -134,8 +131,19 @@
 </div>
 <div style="clear:left;"></div>
 
-<div id="bluephone" class="route-menu-item selected">
+<div id="parkinglots" class="route-menu-item selected">
+<div class="box"></div><div class="color"></div>
+<div class="name">Parking Lots</div>
+</div>
+<div style="clear:left;"></div>
 
+<div id="carcharging" class="route-menu-item selected">
+<div class="box"></div><div class="color"></div>
+<div class="name">Electric Car Charging</div>
+</div>
+<div style="clear:left;"></div>
+
+<div id="bluephone" class="route-menu-item selected">
 <table border=0 cellspacing=0 cellpadding=3 width=100%>
 <tr>
 <td class=box_col align=center><div class='box'></div><div class=color></div></td>
@@ -146,15 +154,9 @@
 </div>
 </fieldset>
 
-<!--<div class=parking>
-<input type=checkbox id="park_garages" /> <label for=park_garages>Parking Garages</label> <br>
-</div>
--->
-
 </div>
 
 </script>
-
 
 <script id="otp-bikesLayer-popup" type="text/html">
 <div>
@@ -203,4 +205,87 @@
 
 </div>
 </script>
+
+<script id="bikeRepair-template" type="text/html">
+<div>
+
+{{#brand}}
+<h3>{{brand}}</h3>
+{{/brand}}
+{{#name}}
+<h3>{{name}}</h3>
+{{/name}}
+
+Bicycle Pump? 
+{{#service:bicycle:pump}}
+{{service:bicycle:pump}}
+{{/service:bicycle:pump}}
+{{^service:bicycle:pump}}
+No
+{{/service:bicycle:pump}}
+<br>
+
+{{#opening_hours}}
+Open: {{opening_hours}}<br>
+{{/opening_hours}}
+
+{{#note}}
+<b>Note</b>: {{ note }}<br>
+{{/note}}
+
+{{#operator}}
+Operated by: {{operator}}<br>
+{{/operator}}
+
+</div>
+</script>
+
+<script id="carCharging-template" type="text/html">
+<div>
+<h3>Electric Vehicle Charging Station</h3>
+
+Provided by <a href="https://na.chargepoint.com/charge_point" target="_blank">Charge Point</a>. <br>
+<br>
+
+<b>Please note:</b> A USF parking permit is required and the vehicle must be charging while using the space. There is no fee for using the charging station. However, there is a 4 hour daily limit. <br>
+<br>
+
+<a href="http://www.usf.edu/administrative-services/parking/parking/ev-charging-stations.aspx" target="_blank">More information</a>
+
+</div>
+</script>
+
+<script id="parkingLots-template" type="text/html">
+<div>
+
+{{#name}}
+<h3>{{ name }}</h3>
+{{/name}}
+{{^name}}
+<h3>Parking Lot</h3>
+{{/name}}
+
+Permit Type(s): {{ permits }}
+<br>
+
+{{#surface}}
+<b>Surface:</b> {{surface}}<br>
+{{/surface}}
+
+{{#building}}
+<b>Building:</b> {{building}}<br>
+{{/building}}
+
+{{#parkmobile }}
+Pay with your Smart Phone using ParkMobile App! (<a href="http://www.usf.edu/administrative-services/parking/parking/parkmobile.aspx" target="_blank">More Info</a>)<br>
+{{/parkmobile}}
+
+{{#note }}
+<b>Note</b>: {{note}}<br>
+{{/note}}
+
+</div>
+</script>
+
+
 	

--- a/src/client/js/otp/widgets/tripoptions/LayersWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/LayersWidget.js
@@ -136,70 +136,97 @@ otp.widgets.LayersWidget =
                	
     });
 
+        // dynamic static/poi layers
+        for (x in otp.config.layersWidget) {
+            opts = otp.config.layersWidget[x];
 
-        // CarShare
-        this.carshare_layer = L.layerGroup();
-        this.carshare_active = false;
+            this[opts['name'] + "_layer"] = L.layerGroup();
+            this[opts['name'] + "_active"] = false;
 
-        carshareicon = L.icon({angle:0, iconUrl: '/images/marker-carshare.svg', iconSize: new L.Point(30,60)});
-
-        marker =  L.marker(L.latLng(28.059951, -82.417575), {icon: carshareicon} );
-        marker.bindPopup("<a target='_blank' href='https://www.enterprisecarshare.com/us/en/programs/university/usf.html'>Reserve a car</a>");
-        marker._leaflet_id = L.stamp(marker);
-        this.carshare_layer.addLayer(marker);
-
-        marker =  L.marker(L.latLng(28.064287, -82.412130), {icon: carshareicon} );
-        marker.bindPopup("<a target='_blank' href='https://www.enterprisecarshare.com/us/en/programs/university/usf.html'>Reserve a car</a>");
-        marker._leaflet_id = L.stamp(marker);
-        this.carshare_layer.addLayer(marker);       
- 
-        $('#carshare').bind('click', {'module': this}, function(ev) {
-
-            if (ev.data.module.carshare_active) {
-                $('#carshare .box').removeClass("active");
-                webapp.map.lmap.removeLayer( ev.data.module.carshare_layer );
+            if (opts['type'] == "static") this.setLayerMarkers( opts, opts['locations'] );
+            else if (opts['type'] == "poi") {
+                $.ajax( otp.config.hostname + '/' + otp.config.restService + '/pois', {
+                    dataType: 'JSON',
+                    data: {query: opts['search']},
+                    context: {'module': this, 'opts': opts},
+                    success: function(data) {
+                        locations = [];
+                        for (x in data) locations.push.apply( locations, data[x] );
+                        this.module.setLayerMarkers( this.opts, locations );
+                    },
+                });
             }
-            else {
-                $('#carshare .box').addClass("active");
-                ev.data.module.carshare_layer.addTo( webapp.map.lmap );
-            }   
 
-            ev.data.module.carshare_active = ! ev.data.module.carshare_active;     
-        });
+            $(opts['target']).bind('click', {'module': this, 'layer': opts}, function(ev) {
 
-        /* Emergency Phones */
-        phones = [[28.0614434,-82.4078041], [28.0555655,-82.4084315], [28.0641975,-82.4185115], [28.0651509,-82.4183224], [28.0652518,-82.4124851], [28.0582386,-82.4225447], [28.0618976,-82.4141717], [28.0615615,-82.4137318], [28.0599592,-82.4069672], [28.0610142,-82.4149218], [28.0591974,-82.4130281], [28.0599166,-82.4078553], [28.0611144,-82.4187288], [28.0630924,-82.4229122], [28.0688995,-82.4130541], [28.0631877,-82.4136464], [28.0632019,-82.4118091], [28.0662717,-82.4191208], [28.0655687,-82.4105538], [28.0641913,-82.4141936], [28.0658575,-82.4130831], [28.0641581,-82.4127264], [28.0652658,-82.4099050], [28.0675588,-82.4256194], [28.0661246,-82.4206762], [28.0660985,-82.4245251], [28.0590405,-82.4201638], [28.0591163,-82.4192972], [28.0582144,-82.4185594], [28.0626681,-82.4144783], [28.0598752,-82.4193438], [28.0628149,-82.4173562], [28.0599651,-82.4176474], [28.0651523,-82.4234651], [28.0603440,-82.4142791], [28.0679737,-82.4155233], [28.0680589,-82.4133400], [28.0663549,-82.4050145], [28.0680589,-82.4053470], [28.0655857,-82.4073694], [28.0666507,-82.4073238], [28.0658389,-82.4087159], [28.0654484,-82.4090968], [28.0665276,-82.4081660], [28.0649845,-82.4113340], [28.0649951,-82.4105895], [28.0669113,-82.4190557], [28.0666677,-82.4197853], [28.0618552,-82.4209247], [28.0678908,-82.4223870], [28.0584771,-82.4084789], [28.0652073,-82.4086336], [28.0661801,-82.4114123], [28.0683646,-82.4098433], [28.0665417,-82.4087582], [28.0665890,-82.4107541], [28.0619428,-82.4029260], [28.0598972,-82.4029098], [28.0668664,-82.4089528], [28.0661730,-82.4098889], [28.0676942,-82.4114296], [28.0685342,-82.4117649], [28.0675338,-82.4091030], [28.0684183,-82.4072753], [28.0600344,-82.4089220], [28.0600490,-82.4100958], [28.0582358,-82.4121799], [28.0591210,-82.4116568], [28.0662335,-82.4029024], [28.0589559,-82.4179827], [28.0596162,-82.4209013], [28.0594457,-82.4185302], [28.0601510,-82.4184505], [28.0630128,-82.4097381], [28.0629156,-82.4104837], [28.0605726,-82.4120424], [28.0610623,-82.4100948], [28.0620187,-82.4113286], [28.0628495,-82.4252844], [28.0567379,-82.4088338], [28.0611240,-82.4071658], [28.0582317,-82.4201016], [28.0617204,-82.4174919], [28.0678858,-82.4176509], [28.0581327,-82.4066318], [28.0626081,-82.4180444], [28.0580570,-82.4029953], [28.0581694,-82.4106393], [28.0583376,-82.4052632], [28.0590952,-82.4174743], [28.0582401,-82.4171404], [28.0591035,-82.4167762]];
-
-        this.phones_layer = L.layerGroup();
-        this.phones_active = false;
-
-        phonesicon = L.icon({angle:0, iconUrl: '/images/marker-bluephone.svg', iconSize: new L.Point(30,60)});
-
-        for (x in phones) {
-            row = phones[x];
-
-            marker =  L.marker(L.latLng(row), {icon: phonesicon} );
-            marker.bindPopup("<b>Use Blue Light Phones to contact Police</b><br><a target='_blank' href='http://www.usf.edu/administrative-services/emergency-management/resources/campus-safety.aspx'>More about campus safety</a>");
-            marker._leaflet_id = L.stamp(marker);
-
-            this.phones_layer.addLayer(marker);
-        }
-
-        $('#bluephone').bind('click', {'module': this}, function(ev) {
-
-                if (ev.data.module.phones_active) {
-                    $('#bluephone .box').removeClass("active");
-                    webapp.map.lmap.removeLayer( ev.data.module.phones_layer );
+                var layerName = ev.data.layer['name'] + "_layer";
+                var activeName = layerName + "_active";
+                var isLayerActive = ev.data.module[ activeName ];
+  
+                if (isLayerActive) {
+                    $(ev.data.layer['target'] + ' .box').removeClass('active');
+                    $(ev.data.layer['target'] + ' .box').css('background-color', 'white');
+                    webapp.map.lmap.removeLayer( ev.data.module[ layerName ] );
                 }
                 else {
-                    $('#bluephone .box').addClass("active");
-                    ev.data.module.phones_layer.addTo( webapp.map.lmap );
-                }
-    
-                ev.data.module.phones_active = ! ev.data.module.phones_active;
-        });
+                    $(ev.data.layer['target'] + ' .box').addClass('active');
+                    $(ev.data.layer['target'] + ' .box').css('background-color', ev.data.layer['color']);
+                    ev.data.module[ layerName ].addTo( webapp.map.lmap );
+                }   
 
-     
+                ev.data.module[activeName] = ! ev.data.module[activeName];
+            })
+        }
+
+        },
+
+    setLayerMarkers: function(opts, locations) {
+            for (y in locations) {
+                y = locations[y];
+ 
+                if ('tags' in y) {
+                    vals = y['tags'];
+
+                    if (y['locations'].split(";").length > 1) {
+                        slat = 0; slng = 0;
+                        num = y['locations'].split(";").length;
+
+                        for (p_id in y['locations'].split(';')) {
+                            p = y['locations'].split(';')[p_id];
+                            slat += parseFloat(p.split(',')[0]);
+                            slng += parseFloat(p.split(',')[1]);
+                        }
+
+                        latlng = [ slat/num, slng/num ];
+                    }
+                    else if (y['locations'].split(',').length > 1) {
+                       v = y['locations'].split(',');
+                       latlng = [ parseFloat(v[0]), parseFloat(v[1]) ];
+                    }
+                    else continue;
+
+                    if ('condition' in opts && ! (opts['condition'] in y['tags'])) continue;
+
+                }
+                else {
+                    latlng = [parseFloat(y[0]), parseFloat(y[1])];
+                    vals = {};
+                }
+
+                marker =  L.marker(L.latLng(latlng[0], latlng[1]), {icon: opts['icon']} );
+                marker._leaflet_id = L.stamp(marker);
+
+                var html = false;
+                if ('popup' in opts) html = opts['popup'];
+                else if ('popupTemplate' in opts) {
+                    html = ich[ opts['popupTemplate'] ]( vals ).html();
+                }
+
+                if (html != false) marker.bindPopup( html );
+
+                this[ opts['name'] + "_layer" ].addLayer( marker );
+            }
+    
     },
     
 });

--- a/src/client/style.css
+++ b/src/client/style.css
@@ -909,6 +909,22 @@ p#splash-text span {
   display: none;
 }
 
+.layersIcon-blue {
+    background: url('/images/marker-blue.svg');
+}
+.layersIcon-green {
+    background: url('/images/marker-green.svg');
+}
+.layersIcon-red {
+    background: url('/images/marker-red.svg');
+}
+.layersIcon i {
+    margin-left: 20%;
+    margin-top: 20%;
+    font-size: 20px;
+    color: white
+}
+
 .other div .box,
 .routes div .box,
 .bikes div .box,
@@ -945,7 +961,7 @@ p#splash-text span {
 	background-color: #f70505; 
 }
 .routes div#usf_E .box.active {
-	background-color: #d4ba13;
+	background-color: #bca510;
 }
 .routes div#usf_F .box.active {
 	background-color: #8f6a51;
@@ -956,19 +972,11 @@ p#splash-text span {
 }
 
 .bikes div#bike_lanes .box.active {
-	background-color: green;
+	background-color: #006747;
 }
 
 .stops div#bus_hart .box.active {
 	background-color: green;
-}
-
-.other div#carshare .box.active {
-    background-color: green;
-}
-
-.other div#bluephone .box.active {
-    background-color: #2880ca;
 }
 
 .box_col {

--- a/src/main/java/org/opentripplanner/api/resource/POIs.java
+++ b/src/main/java/org/opentripplanner/api/resource/POIs.java
@@ -1,0 +1,69 @@
+package org.opentripplanner.api.resource;
+
+import static org.opentripplanner.api.resource.ServerInfo.Q;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+
+import org.opentripplanner.routing.graph.PoiNode;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import lombok.Setter;
+
+import org.opentripplanner.routing.edgetype.PlainStreetEdge;
+import org.opentripplanner.routing.edgetype.StreetTraversalPermission;
+import org.opentripplanner.routing.graph.Edge;
+import org.opentripplanner.routing.graph.Graph;
+import org.opentripplanner.routing.services.GraphService;
+import org.opentripplanner.util.model.EncodedPolylineBean;
+
+@Path("/routers/{routerId}/pois")
+@XmlRootElement
+public class POIs {
+
+    	@Context // FIXME inject Application context
+    	@Setter
+    	private GraphService graphService;
+
+		@GET
+		@Produces({ MediaType.APPLICATION_JSON })
+		public Map<String, ArrayList<PoiNode>> get(@PathParam("routerId") String routerId,
+            @QueryParam("query") String query) {
+
+			Graph g = graphService.getGraph(routerId);
+			if (g == null) return null;
+		
+            // Map for result
+            Map<String, ArrayList<PoiNode>> res = new HashMap<String, ArrayList<PoiNode>>();
+            
+            // Map of matching POI keys 
+            Map<String, ArrayList<PoiNode>> q = new HashMap<String, ArrayList<PoiNode>>();
+
+            // Exact match on POI Key
+            if (g.pois.containsKey( query )) {
+                q.put( query, g.pois.get(query) );
+            }
+            // iterative matching for e.g: key:value* queries
+            else {
+                for (String k : g.pois.keySet()) {
+                    if ( query != null && ! k.toLowerCase().contains( query.toLowerCase() )) continue;
+                    q.put( k, g.pois.get(k) );
+                }
+            }
+
+            // Find all matching PoiNodes, and create JSON string
+            return q;
+		}
+	
+}

--- a/src/main/java/org/opentripplanner/routing/graph/Graph.java
+++ b/src/main/java/org/opentripplanner/routing/graph/Graph.java
@@ -89,6 +89,8 @@ import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Geometry;
 
+import org.opentripplanner.routing.graph.PoiNode;
+
 /**
  * A graph is really just one or more indexes into a set of vertexes. It used to keep edgelists for each vertex, but those are in the vertex now.
  */
@@ -195,6 +197,8 @@ public class Graph implements Serializable {
     	return bikeLanesStr;
     }   
 
+    public Map<String, ArrayList<PoiNode>> pois;
+
     public Graph(Graph basedOn) {
         this();
         this.bundle = basedOn.getBundle();
@@ -205,6 +209,7 @@ public class Graph implements Serializable {
         this.temporaryEdges = Collections.newSetFromMap(new ConcurrentHashMap<Edge, Boolean>());
         this.edgeById = new ConcurrentHashMap<Integer, Edge>();
         this.vertexById = new ConcurrentHashMap<Integer, Vertex>();
+        this.pois = new HashMap<String, ArrayList<PoiNode>>();
     }
     
     /**

--- a/src/main/java/org/opentripplanner/routing/graph/PoiNode.java
+++ b/src/main/java/org/opentripplanner/routing/graph/PoiNode.java
@@ -1,0 +1,40 @@
+/* This program is free software: you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public License
+ as published by the Free Software Foundation, either version 3 of
+ the License, or (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package org.opentripplanner.routing.graph;
+
+import java.io.Serializable;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.IOException;
+import java.lang.ClassNotFoundException;
+
+import java.util.Map;
+
+public class PoiNode implements Serializable {
+        public String type; /* node or way */
+        public String locations; /* list of lat,lng to accomodate way nd refs */
+        public Map<String, String> tags;
+
+        private static final long serialVersionUID = 2L;
+    
+        private void readObject(ObjectInputStream aInputStream) throws ClassNotFoundException, IOException {
+            aInputStream.defaultReadObject();
+        }
+
+        private void writeObject(ObjectOutputStream aOutputStream) throws IOException {
+            aOutputStream.defaultWriteObject();
+        }
+
+}
+

--- a/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
+++ b/src/main/java/org/opentripplanner/standalone/GraphBuilderParameters.java
@@ -1,0 +1,165 @@
+package org.opentripplanner.standalone;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Iterator;
+
+import org.opentripplanner.graph_builder.services.osm.CustomNamer;
+import org.opentripplanner.routing.impl.DefaultFareServiceFactory;
+import org.opentripplanner.routing.services.FareServiceFactory;
+
+import org.opentripplanner.standalone.GraphBuilderParameters;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * These are parameters that when changed, necessitate a Graph rebuild.
+ * They are distinct from the RouterParameters which can be applied to a pre-built graph or on the fly at runtime.
+ * Eventually both classes may be initialized from the same config file so make sure there is no overlap
+ * in the JSON keys used.
+ *
+ * These used to be command line parameters, but there were getting to be too many of them and besides, we want to
+ * allow different graph builder configuration for each Graph.
+ * <p>
+ * TODO maybe have only one giant config file and just annotate the parameters to indicate which ones trigger a rebuild
+ * ...or just feed the same JSON tree to two different classes, one of which is the build configuration and the other is the router configuration.
+ */
+public class GraphBuilderParameters {
+
+    public static double DEFAULT_SUBWAY_ACCESS_TIME = 2.0; // minutes
+
+    /**
+     * Generates nice HTML report of Graph errors/warnings (annotations). They are stored in the same location as the graph.
+     */
+    public final boolean htmlAnnotations;
+
+    /**
+     * If number of annotations is larger then specified number annotations will be split in multiple files.
+     * Since browsers have problems opening large HTML files.
+     */
+    public final int maxHtmlAnnotationsPerFile;
+
+    /**
+     * Include all transit input files (GTFS) from scanned directory.
+     */
+    public final boolean transit;
+
+    /**
+     * Create direct transfer edges from transfers.txt in GTFS, instead of based on distance.
+     */
+    public final boolean useTransfersTxt;
+
+    /**
+     * Link GTFS stops to their parent stops.
+     */
+    public final boolean parentStopLinking;
+
+    /**
+     * Create direct transfers between the constituent stops of each parent station.
+     */
+    public final boolean stationTransfers;
+
+    /**
+     * Minutes necessary to reach stops served by trips on routes of route_type=1 (subway) from the street.
+     * Perhaps this should be a runtime router parameter rather than a graph build parameter.
+     */
+    public final double subwayAccessTime;
+
+    /**
+     * Include street input files (OSM/PBF).
+     */
+    public final boolean streets;
+
+    /**
+     * Embed the Router config in the graph, which allows it to be sent to a server fully configured over the wire.
+     */
+    public final boolean embedRouterConfig;
+
+    /**
+     * Perform visibility calculations on OSM areas (these calculations can be time consuming).
+     */
+    public final boolean areaVisibility;
+
+    /**
+     * Based on GTFS shape data, guess which OSM streets each bus runs on to improve stop linking.
+     */
+    public final boolean matchBusRoutesToStreets;
+
+    /**
+     * Download US NED elevation data and apply it to the graph.
+     */
+    public final boolean fetchElevationUS;
+
+    /**
+     * A specific fares service to use.
+     */
+
+    /**
+     * A custom OSM namer to use.
+     */
+
+    /**
+     * Whether bike rental stations should be loaded from OSM, rather than periodically dynamically pulled from APIs.
+     */
+    public boolean staticBikeRental = false;
+
+    /**
+     * Whether we should create car P+R stations from OSM data.
+     */
+    public boolean staticParkAndRide = true;
+
+    /**
+     * Whether we should create bike P+R stations from OSM data.
+     */
+    public boolean staticBikeParkAndRide = false;
+
+    /**
+      * Map of points of interest that we should find and save in the graph from OSM. 
+      * 'tag_to_search_for': { 'value': ['related_settings'], },
+      */
+    public Map<String, List<JsonNode>> pois;
+ 
+    /**
+     * Set all parameters from the given Jackson JSON tree, applying defaults.
+     * Supplying MissingNode.getInstance() will cause all the defaults to be applied.
+     * This could be done automatically with the "reflective query scraper" but it's less type safe and less clear.
+     * Until that class is more type safe, it seems simpler to just list out the parameters by name here.
+     */
+    public GraphBuilderParameters(JsonNode config) {
+
+        htmlAnnotations = config.path("htmlAnnotations").asBoolean(false);
+        transit = config.path("transit").asBoolean(true);
+        useTransfersTxt = config.path("useTransfersTxt").asBoolean(false);
+        parentStopLinking = config.path("parentStopLinking").asBoolean(false);
+        stationTransfers = config.path("stationTransfers").asBoolean(false);
+        subwayAccessTime = config.path("subwayAccessTime").asDouble(DEFAULT_SUBWAY_ACCESS_TIME);
+        streets = config.path("streets").asBoolean(true);
+        embedRouterConfig = config.path("embedRouterConfig").asBoolean(true);
+        areaVisibility = config.path("areaVisibility").asBoolean(false);
+        matchBusRoutesToStreets = config.path("matchBusRoutesToStreets").asBoolean(false);
+        fetchElevationUS = config.path("fetchElevationUS").asBoolean(false);
+        staticBikeRental = config.path("staticBikeRental").asBoolean(false);
+        staticParkAndRide = config.path("staticParkAndRide").asBoolean(true);
+        staticBikeParkAndRide = config.path("staticBikeParkAndRide").asBoolean(false);
+        maxHtmlAnnotationsPerFile = config.path("maxHtmlAnnotationsPerFile").asInt(1000);
+
+        pois = new HashMap<String, List<JsonNode>>();
+        for (Iterator<Map.Entry<String, JsonNode>> it = config.path("pois").fields(); it.hasNext(); ) {
+            Map.Entry<String, JsonNode> r = it.next();
+
+            for (Iterator<Map.Entry<String, JsonNode>> it2 = r.getValue().fields(); it2.hasNext(); ) {
+                Map.Entry<String, JsonNode> node = it2.next();
+                String tagName = String.format("%s:%s", r.getKey(), node.getKey());
+// XXX instead of key:name, use an object with tag, value properties
+
+                if (!pois.containsKey( tagName )) pois.put( tagName, new ArrayList<JsonNode>() );
+
+                pois.get(tagName).add( node.getValue() );
+            }
+        }
+
+    }
+
+}

--- a/src/main/java/org/opentripplanner/standalone/OTPApplication.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPApplication.java
@@ -10,6 +10,7 @@ import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature;
 import org.opentripplanner.api.common.OTPExceptionMapper;
 import org.opentripplanner.api.model.JSONObjectMapperProvider;
 import org.opentripplanner.api.resource.AlertPatcher;
+import org.opentripplanner.api.resource.POIs;
 import org.opentripplanner.api.resource.BikeLanes;
 import org.opentripplanner.api.resource.BikeRental;
 import org.opentripplanner.api.resource.ExternalGeocoderResource;
@@ -81,6 +82,7 @@ public class OTPApplication extends Application {
             GeocoderResource.class,
             SimpleIsochrone.class,
             TileService.class,
+            POIs.class,
             BikeLanes.class,
             BikeRental.class,
             LIsochrone.class,

--- a/src/main/java/org/opentripplanner/standalone/OTPConfigurator.java
+++ b/src/main/java/org/opentripplanner/standalone/OTPConfigurator.java
@@ -120,6 +120,8 @@ public class OTPConfigurator {
         List<File> gtfsFiles = Lists.newArrayList();
         List<File> osmFiles =  Lists.newArrayList();
         File configFile = null;
+        GraphBuilderParameters buildConfig = null;
+
         /* For now this is adding files from all directories listed, rather than building multiple graphs. */
         for (File dir : params.build) {
             LOG.info("Searching for graph builder input files in {}", dir);
@@ -144,6 +146,9 @@ public class OTPConfigurator {
                         configFile = file;
                     }
                     break;
+                case BUILD_CONFIG:
+                           buildConfig = new GraphBuilderParameters( OTPMain.loadJson( file ) );
+                           break;
                 case OTHER:
                     LOG.debug("Skipping file '{}'", file);
                 }
@@ -165,6 +170,9 @@ public class OTPConfigurator {
             DefaultWayPropertySetSource defaultWayPropertySetSource = new DefaultWayPropertySetSource();
             osmBuilder.setDefaultWayPropertySetSource(defaultWayPropertySetSource);
             osmBuilder.skipVisibility = params.skipVisibility;
+
+            if (buildConfig != null) osmBuilder.setBuildConfig( buildConfig ); 
+
             graphBuilder.addGraphBuilder(osmBuilder);
             graphBuilder.addGraphBuilder(new PruneFloatingIslands());            
         }
@@ -233,7 +241,7 @@ public class OTPConfigurator {
     }
 
     private static enum InputFileType {
-        GTFS, OSM, CONFIG, OTHER;
+        GTFS, OSM, CONFIG, BUILD_CONFIG, OTHER;
         public static InputFileType forFile(File file) {
             String name = file.getName();
             if (name.endsWith(".zip")) {
@@ -248,6 +256,7 @@ public class OTPConfigurator {
             if (name.endsWith(".osm")) return OSM;
             if (name.endsWith(".osm.xml")) return OSM;
             if (name.equals("Embed.properties")) return CONFIG;
+            if (name.equals("build-config.json")) return BUILD_CONFIG;
             return OTHER;
         }
     }


### PR DESCRIPTION
Filtering of returned points supported via "q" request parameter.

Map Builds now support build-config.json:

{
 pois: { amenity: {
                     parking: [],
                     bicycle_repair_station: [],
                     bicycle_parking: [],
                     charging_station: [],
                     fast_food: [],
                     restaurant: []
                  },
         shop:    {
                     supermarket: []
                  },
         sport: {
                    soccer: [],
                    baseball: [],
                    football: [],
                    softball: [],
                    basketball: [],
                    tennis: [],
                    running: []
                }
        }
}

And frontend UI configured using js/otp/config.js

layersWidget: {}
     { name: 'parking', target: '#parkinglots', icon: new L.layersIcon({icon: 'mdi mdi-parking', color: 'red'}), type: 'poi', search: 'amenity:parking', popupTemplate: 'parkingLots-template', condition: "permits", color: "red" },

```
Target is DOM selector defined in the client, typically in the layer widget template: usf-layer-menu in layers/layers-templates.html

Templates stored in js/otp/layers/layers-templates.html
Search matches key=value based on backend API "q" param
```

Route E color, and bike lanes updated fixes #204

Add links for EV stations for #227

Also for #177, #179
