### PR TITLE
Fix car charging mobile alignment in layers widget

### DIFF
--- a/src/client/js/otp/layers/layers-templates.html
+++ b/src/client/js/otp/layers/layers-templates.html
@@ -103,8 +103,12 @@
 <div style="clear:left;"></div>
 
 <div id="bikerepair" class="route-menu-item selected">
-<div class="box"></div><div class="color"></div>
-<div class="name">Bike Repair Stations</div>
+<table border=0 cellspacing=0 cellpadding=3 width=100%>
+<tr>
+<td class=box_col align=center><div class='box'></div><div class=color></div></td>
+<td width=90%><div class="name">Bike Repair Stations</div></td>
+</tr>
+</table>
 </div>
 <div style="clear:left;"></div>
 
@@ -138,8 +142,12 @@
 <div style="clear:left;"></div>
 
 <div id="carcharging" class="route-menu-item selected">
-<div class="box"></div><div class="color"></div>
-<div class="name">Electric Car Charging</div>
+<table border=0 cellspacing=0 cellpadding=3 width=100%>
+<tr>
+<td class=box_col align=center><div class='box'></div><div class=color></div></td>
+<td width=90%><div class="name">Electric Car Charging</div></td>
+</tr>
+</table>
 </div>
 <div style="clear:left;"></div>
 


### PR DESCRIPTION
Change bike repair stations and car charging in layers widget to use table instead of div so it doesn't cascade to another line on smaller screens. Fixes #252
