### PR TITLE
fixes #235. the info widgets cannot be minimized but closed only.

### DIFF
--- a/src/client/js/otp/widgets/InfoWidget.js
+++ b/src/client/js/otp/widgets/InfoWidget.js
@@ -22,7 +22,7 @@ otp.widgets.InfoWidget =
 	    var defaultOptions = {
 	        cssClass : 'otp-defaultInfoWidget',
             closeable : true,
-            minimizable : true,
+            minimizable : false,
             openInitially : false,
 	    };
 	    

--- a/src/client/js/otp/widgets/Widget.js
+++ b/src/client/js/otp/widgets/Widget.js
@@ -25,7 +25,7 @@ otp.widgets.Widget = otp.Class({
     customHeader	: false, // custom header option
     // fields that can be set via the options parameter, and default values:
     draggable       : true,
-    minimizable     : true,
+    minimizable     : false,
     closeable       : true,
     resizable       : false,
     showHeader      : true,


### PR DESCRIPTION
Screenshot for desktop:
![image](https://cloud.githubusercontent.com/assets/1370401/14531475/72e791cc-022b-11e6-9d8e-df33dbdf778e.png)

Screenshot for mobile:
![image](https://cloud.githubusercontent.com/assets/1370401/14531462/6ad07076-022b-11e6-8ebc-803212afb706.png)
