### PR TITLE
Temporarily remove hub reservation links and space information

### DIFF
--- a/src/client/js/otp/layers/layers-templates.html
+++ b/src/client/js/otp/layers/layers-templates.html
@@ -202,15 +202,6 @@
 <div class="cell width_7">{{station.bikesAvailable}}</div>
 </div>
 
-<div class="row">
-<div class="cell width_3"><strong>SPACES:</strong></div>
-<div class="cell width_7">{{station.spacesAvailable}}</div>
-</div>
-
-<div class="row center">
-<a target="_blank" href="{{reserve_link}}">Reserve a bike from this hub</a>
-</div>
-
 </div>
 </script>
 


### PR DESCRIPTION
 until the links actually work, and SoBi implements the capacity field to their GBFS feed
