### PR TITLE
Fix request logging backport

### DIFF
--- a/src/main/java/org/opentripplanner/api/parameter/QualifiedModeSetSequence.java
+++ b/src/main/java/org/opentripplanner/api/parameter/QualifiedModeSetSequence.java
@@ -26,6 +26,7 @@ public class QualifiedModeSetSequence {
     public List<Set<QualifiedMode>> sets = Lists.newArrayList();
 
     public QualifiedModeSetSequence(String s) {
+
         for (String seg : s.split(";")) {
             Set<QualifiedMode> qModeSet = Sets.newHashSet();
             for (String qMode : seg.split(",")) {
@@ -48,6 +49,7 @@ public class QualifiedModeSetSequence {
         req.modes = new TraverseModeSet();
         /* Use only the first set of qualified modes for now. */
         if (sets.isEmpty()) return;
+
         Set<QualifiedMode> qModes = sets.get(0);
         // First, copy over all the modes
         for (QualifiedMode qMode : qModes) {
@@ -72,6 +74,21 @@ public class QualifiedModeSetSequence {
                 }
             }
         }
+    }
+
+    public String asString() {
+        StringBuilder sb = new StringBuilder();
+
+        /* Use only the first set of qualified modes for now. */
+        if (sets.isEmpty()) return null;
+        Set<QualifiedMode> qModes = sets.get(0);
+ 
+        for (QualifiedMode qm : qModes) {
+            sb.append(qm.mode);
+            sb.append(",");
+        }
+
+        return sb.toString();
     }
 
 }

--- a/src/main/java/org/opentripplanner/api/resource/Planner.java
+++ b/src/main/java/org/opentripplanner/api/resource/Planner.java
@@ -69,7 +69,7 @@ public class Planner extends RoutingResource {
          * TODO: org.opentripplanner.routing.impl.PathServiceImpl has COOORD parsing. Abstract that
          *       out so it's used here too...
          */
-        
+      
         // create response object, containing a copy of all request parameters
         Response response = new Response(uriInfo);
         RoutingRequest request = null;
@@ -92,7 +92,7 @@ public class Planner extends RoutingResource {
                 sb.append(' ');
                 sb.append(LocalDateTime.ofInstant(Instant.ofEpochSecond(request.dateTime), ZoneId.systemDefault()));
                 sb.append(' ');
-                sb.append(request.modes.getAsStr());
+                sb.append(modes.get(0).asString());
                 sb.append(' ');
                 sb.append(request.from.getLat());
                 sb.append(' ');


### PR DESCRIPTION
From  PR #269 - missing a method to properly convert the requested list of modes to a string.

This brings that from upstream and fixes the logged modes to be only those specified by the user and not everything available.
