### PR TITLE
Defer initialize JS code and switch from jquery document to window load event

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -186,11 +186,11 @@
 
 
 <!-- load ICH templates and create the webapp at startup -->
-<script type="text/javascript" language="javascript">
+<script type="text/javascript" defer>
 
 var webapp = null;
 
-$(document).ready(function() {
+$(window).load(function() {
     var templateUrls = [ //new Array(
         'js/otp/layers/layers-templates.html',
         'js/otp/widgets/widget-templates.html',


### PR DESCRIPTION
which ensures $(window).height() is available when widgets are rendered.

Fixes #293
