### PR TITLE
Migrate to Universal Google Analytics, Add event tracking

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -233,26 +233,26 @@ $(document).ready(function() {
             onClick=" document.cookie = 'widgetUsed=trip; expires=' + moment().add(moment.duration({'years':1})).format('ddd, D MMM YYYY HH:mm:ss zz') + ' UTC';
                      document.location.hash = 'trip';
                      jQuery('#layersButton').removeClass('selected_item'); jQuery('#tripPlannerButton').addClass('selected_item');
-                     javascript:webapp.modules[0].optionsWidget.show();"> 
+                     javascript:webapp.modules[0].optionsWidget.show(); logGAEvent('click', 'link', 'trip planner'); "> 
             <i class="material-icons" >directions</i>
                 Trip planner</li>
             <li class="mdl-menu__item" id="layersButton"
                 onClick=" document.cookie = 'widgetUsed=layers; expires=' + moment().add(moment.duration({'years':1})).format('ddd, D MMM YYYY HH:mm:ss zz') + ' UTC';
                           document.location.hash = 'layers';
                           jQuery('#tripPlannerButton').removeClass('selected_item'); jQuery('#layersButton').addClass('selected_item');
-                          javascript:webapp.modules[0].layerWidget.show();">
+                          javascript:webapp.modules[0].layerWidget.show(); logGAEvent('click', 'link', 'layers'); ">
             <i class="material-icons" >layers</i>
                 Layers</li>
             <li><hr class="menu_separator"></li>
             <li class="mdl-menu__item" 
                 onClick="javascript:webapp.infoWidgets['otp-infoWidget-0'].show();
                          jQuery('#layersButton').removeClass('selected_item'); 
-                         jQuery('#tripPlannerButton').removeClass('selected_item');"
+                         jQuery('#tripPlannerButton').removeClass('selected_item'); logGAEvent('click', 'link', 'help widget');"
                 >Help</li> 
             <li class="mdl-menu__item" 
                 onClick="javascript:webapp.infoWidgets['otp-infoWidget-1'].show();
                          jQuery('#layersButton').removeClass('selected_item');
-                         jQuery('#tripPlannerButton').removeClass('selected_item');" 
+                         jQuery('#tripPlannerButton').removeClass('selected_item'); logGAEvent('click', 'link', 'feedback widget');" 
                 >Send feedback</li> 
             <!-- the button help need to be link to the icon legend pop up -->
         </ul>
@@ -270,19 +270,27 @@ $(document).ready(function() {
 
 <div id="otp-spinner"><img src="images/spinner.gif"></div>
 
+<!-- Google Analytics -->
 <script type="text/javascript">
+function logGAEvent(action, category, label) {
+    ga('send', 'event', category, action, label);
+}
 
-  var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-69486080-1']);
-  _gaq.push(['_trackPageview']);
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-  (function() {
-    var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-    ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
-  })();
+ga('create', 'UA-69486080-1', 'auto');
+
+is_myusf = navigator.userAgent.toLowerCase().indexOf('pyxismobile') > 0;
+if (is_myusf) ga('set', 'campaignSource', 'MyUSF Android');
+
+ga('send', 'pageview');
 
 </script>
+<!-- End Google Analytics -->
+
 
 </body>
 </html>

--- a/src/client/js/otp/modules/planner/PlannerModule.js
+++ b/src/client/js/otp/modules/planner/PlannerModule.js
@@ -517,7 +517,9 @@ otp.modules.planner.PlannerModule =
     },
  
     planTrip : function(existingQueryParams, apiMethod) {
-    
+   
+    logGAEvent('click', 'link', 'plan trip');
+
         if(typeof this.planTripStart == 'function') this.planTripStart();
 
 	this._queryParams = existingQueryParams;

--- a/src/client/js/otp/widgets/Widget.js
+++ b/src/client/js/otp/widgets/Widget.js
@@ -220,7 +220,7 @@ otp.widgets.Widget = otp.Class({
     center : function() {
         var left = $(window).width()/2 - this.$().width()/2;
         var top = $(window).height()/2 - this.$().height()/2;
-        
+ 
         this.$().offset({ top : top, left: left });
     },
 

--- a/src/client/js/otp/widgets/tripoptions/LayersWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/LayersWidget.js
@@ -24,7 +24,10 @@ otp.widgets.LayersWidget =
     	
     	var id = L.stamp( this.module.busLayers );
     	var obj = this.module.busLayers;
-    	        	
+
+        var on_off = (obj.visible.indexOf(rte) != -1) ? "OFF" : "ON";
+        logGAEvent('click', 'link', 'layers bullrunner ' + rte + ' ' + on_off);
+
     	if (obj.visible.indexOf(rte) != -1) { 
     		obj.visible.splice(obj.visible.indexOf(rte), 1);
     		$('#usf_'+rte+' .box').removeClass('active');
@@ -78,37 +81,28 @@ otp.widgets.LayersWidget =
 	// Bullrunner bus stops+routes
         $('#usf_A').bind('click', {'this_': this}, function(ev) {
         	this_.toggle_bus_layer("A");
-
-            logGAEvent('click', 'link', 'layers bullrunner A'); 
         });
         $('#usf_B').bind('click', {'this_': this}, function(ev) {
         	this_.toggle_bus_layer("B");        	        
-
-            logGAEvent('click', 'link', 'layers bullrunner B');
         });
         $('#usf_C').bind('click', {'this_': this}, function(ev) {
         	this_.toggle_bus_layer("C");        	        
-
-            logGAEvent('click', 'link', 'layers bullrunner C');
         });
         $('#usf_D').bind('click', {'this_': this}, function(ev) {
         	this_.toggle_bus_layer("D");        	        
-
-            logGAEvent('click', 'link', 'layers bullrunner D');
         });
         $('#usf_E').bind('click', {'this_': this}, function(ev) {
         	this_.toggle_bus_layer("E");        	        
-
-            logGAEvent('click', 'link', 'layers bullrunner E');
         });
         $('#usf_F').bind('click', {'this_': this}, function(ev) {
         	this_.toggle_bus_layer("F");        	        
-
-            logGAEvent('click', 'link', 'layers bullrunner F');
         });
       
 	// HART bus stops
 	$('#bus_hart').bind('click', {'module': this.module}, function(ev) {
+
+        var on_off = (otp.config.showHartBusStops) ? "OFF" : "ON";
+        logGAEvent('click', 'link', 'layers hart stops ' + on_off);
 
 		if (otp.config.showHartBusStops) {
 			otp.config.showHartBusStops = false;
@@ -120,15 +114,16 @@ otp.widgets.LayersWidget =
 		}
 
 		ev.data.module.stopsLayer.refresh();
-
-        logGAEvent('click', 'link', 'layers hart stops');
 	});
   
 	// Bike rental layers
     $('#bike_stations').bind('click', {'module': this.module}, function(ev) {
 
         var id = L.stamp( ev.data.module.bikeLayers );
-        	                	
+
+        var on_off = (ev.data.module.bikeLayers.visible) ? "OFF" : "ON";        	                	
+        logGAEvent('click', 'link', 'layers bike stations ' + on_off);        	
+
        	if (ev.data.module.bikeLayers.visible) {
        		ev.data.module.bikeLayers.visible = false;
 	   		$("#bike_stations .box").removeClass('active');
@@ -139,12 +134,13 @@ otp.widgets.LayersWidget =
 	    }
 		
     	ev.data.module.bikeLayers.setMarkers(); // refresh
-
-        logGAEvent('click', 'link', 'layers bike stations');        	
     });
 
     $('#bike_lanes').bind('click', {'module': this.module}, function(ev) {
-       
+
+        var on_off = (ev.data.module.bikeLanes.visible) ? "OFF" : "ON";       
+        logGAEvent('click', 'link', 'layers bike lanes ' + on_off);
+
 		if (ev.data.module.bikeLanes.visible) {
 			ev.data.module.bikeLanes.visible = false;
 			$("#bike_lanes .box").removeClass('active');
@@ -154,10 +150,7 @@ otp.widgets.LayersWidget =
 			$("#bike_lanes .box").addClass('active');
 		}
 
-		ev.data.module.bikeLanes.refresh(); 
-
-        logGAEvent('click', 'link', 'layers bike lanes');
-               	
+		ev.data.module.bikeLanes.refresh();               	
     });
 
         // dynamic static/poi layers
@@ -200,7 +193,8 @@ otp.widgets.LayersWidget =
 
                 ev.data.module[activeName] = ! ev.data.module[activeName];
 
-                logGAEvent('click', 'link', 'layers ' + ev.data.layer['name']);
+                var on_off = (isLayerActive) ? "OFF" : "ON";
+                logGAEvent('click', 'link', 'layers ' + ev.data.layer['name'] + ' ' + on_off);
             })
         }
 

--- a/src/client/js/otp/widgets/tripoptions/LayersWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/LayersWidget.js
@@ -77,22 +77,34 @@ otp.widgets.LayersWidget =
         
 	// Bullrunner bus stops+routes
         $('#usf_A').bind('click', {'this_': this}, function(ev) {
-        	this_.toggle_bus_layer("A");        	        
+        	this_.toggle_bus_layer("A");
+
+            logGAEvent('click', 'link', 'layers bullrunner A'); 
         });
         $('#usf_B').bind('click', {'this_': this}, function(ev) {
         	this_.toggle_bus_layer("B");        	        
+
+            logGAEvent('click', 'link', 'layers bullrunner B');
         });
         $('#usf_C').bind('click', {'this_': this}, function(ev) {
         	this_.toggle_bus_layer("C");        	        
+
+            logGAEvent('click', 'link', 'layers bullrunner C');
         });
         $('#usf_D').bind('click', {'this_': this}, function(ev) {
         	this_.toggle_bus_layer("D");        	        
+
+            logGAEvent('click', 'link', 'layers bullrunner D');
         });
         $('#usf_E').bind('click', {'this_': this}, function(ev) {
         	this_.toggle_bus_layer("E");        	        
+
+            logGAEvent('click', 'link', 'layers bullrunner E');
         });
         $('#usf_F').bind('click', {'this_': this}, function(ev) {
         	this_.toggle_bus_layer("F");        	        
+
+            logGAEvent('click', 'link', 'layers bullrunner F');
         });
       
 	// HART bus stops
@@ -109,6 +121,7 @@ otp.widgets.LayersWidget =
 
 		ev.data.module.stopsLayer.refresh();
 
+        logGAEvent('click', 'link', 'layers hart stops');
 	});
   
 	// Bike rental layers
@@ -126,7 +139,8 @@ otp.widgets.LayersWidget =
 	    }
 		
     	ev.data.module.bikeLayers.setMarkers(); // refresh
-        	
+
+        logGAEvent('click', 'link', 'layers bike stations');        	
     });
 
     $('#bike_lanes').bind('click', {'module': this.module}, function(ev) {
@@ -141,6 +155,8 @@ otp.widgets.LayersWidget =
 		}
 
 		ev.data.module.bikeLanes.refresh(); 
+
+        logGAEvent('click', 'link', 'layers bike lanes');
                	
     });
 
@@ -183,6 +199,8 @@ otp.widgets.LayersWidget =
                 }   
 
                 ev.data.module[activeName] = ! ev.data.module[activeName];
+
+                logGAEvent('click', 'link', 'layers ' + ev.data.layer['name']);
             })
         }
 


### PR DESCRIPTION
Add initial event logging to send tracking beacons for menu item clicks, trip planner requests, and clicks in the layers widget.

Also, track navigator.userAgent for MyUSF Android and set campaign source accordingly if found.

Fixes #296, #294
