### PR TITLE
Fix to wrong size of the trip summary in "itinerary returned" widget and Trip summary colour depending on the mode.

### DIFF
--- a/src/client/js/otp/modules/planner/ItinerariesWidget.js
+++ b/src/client/js/otp/modules/planner/ItinerariesWidget.js
@@ -259,14 +259,17 @@ otp.widgets.ItinerariesWidget =
         var div = $('<div style="position: relative; height: 20px;"></div>').appendTo(parentDiv);
         div.append('<div class="otp-itinsAccord-header-number">'+(index+1)+'.</div>');
         
-        var maxSpan = itin.tripPlan.latestEndTime - itin.tripPlan.earliestStartTime;
-        var startPct = (itin.itinData.startTime - itin.tripPlan.earliestStartTime) / maxSpan;
-        var itinSpan = itin.getEndTime() - itin.getStartTime();
+        //var maxSpan = itin.tripPlan.latestEndTime - itin.tripPlan.earliestStartTime;
+        var maxSpan = itin.itinData.endTime - itin.itinData.startTime;
+        //var startPct = (itin.itinData.startTime - itin.tripPlan.earliestStartTime) / maxSpan;
+        //var itinSpan = itin.getEndTime() - itin.getStartTime();
         var timeWidth = 50;
         var startPx = 20+timeWidth, endPx = div.width()-timeWidth - (itin.groupSize ? 48 : 0);
         var pxSpan = endPx-startPx;
-        var leftPx = startPx + startPct * pxSpan;
-        var widthPx = pxSpan * (itinSpan / maxSpan);
+        //var leftPx = startPx + startPct * pxSpan;
+        var leftPx = startPx;
+        //var widthPx = pxSpan * (itinSpan / maxSpan);
+        var widthPx = pxSpan;
 
         div.append('<div style="position:absolute; width: '+(widthPx+5)+'px; height: 2px; left: '+(leftPx-2)+'px; top: 9px; background: black;" />');
         
@@ -279,23 +282,36 @@ otp.widgets.ItinerariesWidget =
         div.append('<div class="otp-itinsAccord-header-time" style="left: '+(leftPx+widthPx+2)+'px;">' + timeStr + '</div>');
         
         for(var l=0; l<itin.itinData.legs.length; l++) {
+            var minimumIconlength = ((itin.itinData.legs.length * 20) > pxSpan) ? (pxSpan / itin.itinData.legs.length) : 20;
             var leg = itin.itinData.legs[l];
-            var startPct = (leg.startTime - itin.tripPlan.earliestStartTime) / maxSpan;
+            var startPct = (leg.startTime - itin.itinData.startTime) / maxSpan;
+            //var startPct = (leg.startTime - itin.tripPlan.earliestStartTime) / maxSpan;
             var endPct = (leg.endTime - itin.tripPlan.earliestStartTime) / maxSpan;
-            var leftPx = startPx + startPct * pxSpan + 1;
-            var widthPx = pxSpan * (leg.endTime - leg.startTime) / maxSpan - 1;
+            //var leftPx = startPx + startPct * pxSpan + 1;
+            var leftPx = startPx + startPct * (pxSpan - minimumIconlength * itin.itinData.legs.length) + l * minimumIconlength + 1;
+            var widthPx = (pxSpan - minimumIconlength * itin.itinData.legs.length) * (leg.endTime - leg.startTime) / maxSpan + minimumIconlength - 2;
     
             //div.append('<div class="otp-itinsAccord-header-segment" style="width: '+widthPx+'px; left: '+leftPx+'px; background: '+this.getModeColor(leg.mode)+' url(images/mode/'+leg.mode.toLowerCase()+'.png) center no-repeat;"></div>');
-            if (leg.mode == "BICYCLE") darkmode = "_darkbg";
-            else darkmode = "";
- 
+            //if (leg.mode == "BICYCLE") darkmode = "_darkbg";
+            //else darkmode = "";
+            darkmode = "";
+            var colour = this.getModeColor(leg.mode);
+            if (leg.agencyId == "Hillsborough Area Regional Transit") colour = '#0084fc';
+            else if (leg.agencyId == "USF Bull Runner") {
+				if (leg.routeShortName == 'A') colour = '#00883c';
+                else if (leg.routeShortName == 'B') colour = '#00a1d1';
+                else if (leg.routeShortName == 'C') colour = '#AC49D0';
+                else if (leg.routeShortName == 'D') colour = '#F70505';
+                else if (leg.routeShortName == 'E') colour = '#bca510';
+                else if (leg.routeShortName == 'F') colour = '#8F6A51';
+            }                
             var showRouteLabel = widthPx > 40 && otp.util.Itin.isTransit(leg.mode) && leg.routeShortName && leg.routeShortName.length <= 6;
             var segment = $('<div class="otp-itinsAccord-header-segment" />')
             .css({
                 width: widthPx,
                 left: leftPx,
                 //background: this.getModeColor(leg.mode)
-                background: this.getModeColor(leg.mode)+' url('+otp.config.resourcePath+'images/mode/'+leg.mode.toLowerCase()+darkmode+'.png) center no-repeat'
+                background: colour +' url('+otp.config.resourcePath+'images/mode/'+leg.mode.toLowerCase()+darkmode+'.png) center no-repeat'
             })
             .appendTo(div);
             if(showRouteLabel) segment.append('<div style="margin-left:'+(widthPx/2+9)+'px;">'+leg.routeShortName+'</div>');
@@ -311,7 +327,7 @@ otp.widgets.ItinerariesWidget =
 
     getModeColor : function(mode) {
         if(mode === "WALK") return '#bbb';
-        if(mode === "BICYCLE") return '#44f';
+        if(mode === "BICYCLE") return '#00eb00';
         if(mode === "SUBWAY") return '#f00';
         if(mode === "RAIL") return '#b00';
         if(mode === "BUS") return '#0f0';

--- a/src/client/js/otp/modules/planner/ItinerariesWidget.js
+++ b/src/client/js/otp/modules/planner/ItinerariesWidget.js
@@ -259,16 +259,11 @@ otp.widgets.ItinerariesWidget =
         var div = $('<div style="position: relative; height: 20px;"></div>').appendTo(parentDiv);
         div.append('<div class="otp-itinsAccord-header-number">'+(index+1)+'.</div>');
         
-        //var maxSpan = itin.tripPlan.latestEndTime - itin.tripPlan.earliestStartTime;
         var maxSpan = itin.itinData.endTime - itin.itinData.startTime;
-        //var startPct = (itin.itinData.startTime - itin.tripPlan.earliestStartTime) / maxSpan;
-        //var itinSpan = itin.getEndTime() - itin.getStartTime();
         var timeWidth = 50;
         var startPx = 20+timeWidth, endPx = div.width()-timeWidth - (itin.groupSize ? 48 : 0);
         var pxSpan = endPx-startPx;
-        //var leftPx = startPx + startPct * pxSpan;
         var leftPx = startPx;
-        //var widthPx = pxSpan * (itinSpan / maxSpan);
         var widthPx = pxSpan;
 
         div.append('<div style="position:absolute; width: '+(widthPx+5)+'px; height: 2px; left: '+(leftPx-2)+'px; top: 9px; background: black;" />');
@@ -285,20 +280,15 @@ otp.widgets.ItinerariesWidget =
             var minimumIconlength = ((itin.itinData.legs.length * 20) > pxSpan) ? (pxSpan / itin.itinData.legs.length) : 20;
             var leg = itin.itinData.legs[l];
             var startPct = (leg.startTime - itin.itinData.startTime) / maxSpan;
-            //var startPct = (leg.startTime - itin.tripPlan.earliestStartTime) / maxSpan;
             var endPct = (leg.endTime - itin.tripPlan.earliestStartTime) / maxSpan;
-            //var leftPx = startPx + startPct * pxSpan + 1;
             var leftPx = startPx + startPct * (pxSpan - minimumIconlength * itin.itinData.legs.length) + l * minimumIconlength + 1;
             var widthPx = (pxSpan - minimumIconlength * itin.itinData.legs.length) * (leg.endTime - leg.startTime) / maxSpan + minimumIconlength - 2;
     
             //div.append('<div class="otp-itinsAccord-header-segment" style="width: '+widthPx+'px; left: '+leftPx+'px; background: '+this.getModeColor(leg.mode)+' url(images/mode/'+leg.mode.toLowerCase()+'.png) center no-repeat;"></div>');
-            //if (leg.mode == "BICYCLE") darkmode = "_darkbg";
-            //else darkmode = "";
-            darkmode = "";
             var colour = this.getModeColor(leg.mode);
             if (leg.agencyId == "Hillsborough Area Regional Transit") colour = '#0084fc';
             else if (leg.agencyId == "USF Bull Runner") {
-				if (leg.routeShortName == 'A') colour = '#00883c';
+		if (leg.routeShortName == 'A') colour = '#00883c';
                 else if (leg.routeShortName == 'B') colour = '#00a1d1';
                 else if (leg.routeShortName == 'C') colour = '#AC49D0';
                 else if (leg.routeShortName == 'D') colour = '#F70505';
@@ -311,7 +301,7 @@ otp.widgets.ItinerariesWidget =
                 width: widthPx,
                 left: leftPx,
                 //background: this.getModeColor(leg.mode)
-                background: colour +' url('+otp.config.resourcePath+'images/mode/'+leg.mode.toLowerCase()+darkmode+'.png) center no-repeat'
+                background: colour +' url('+otp.config.resourcePath+'images/mode/'+leg.mode.toLowerCase()+'.png) center no-repeat'
             })
             .appendTo(div);
             if(showRouteLabel) segment.append('<div style="margin-left:'+(widthPx/2+9)+'px;">'+leg.routeShortName+'</div>');

--- a/src/client/js/otp/modules/planner/PlannerModule.js
+++ b/src/client/js/otp/modules/planner/PlannerModule.js
@@ -701,8 +701,15 @@ otp.modules.planner.PlannerModule =
             if (leg.agencyId == "Hillsborough Area Regional Transit") {
                 polyline.setStyle({ color : '#0000FF', weight: weight });
             }
-            else if (leg.agencyId == "USF Bull Runner") { 
-                polyline.setStyle({ color: '#080', weight: weight });
+            else if (leg.agencyId == "USF Bull Runner") {
+                var colour = '#080';
+                if (leg.routeShortName == 'A') colour = '#00573C';
+                else if (leg.routeShortName == 'B') colour = '#0077D1';
+                else if (leg.routeShortName == 'C') colour = '#AC49D0';
+                else if (leg.routeShortName == 'D') colour = '#F70505';
+                else if (leg.routeShortName == 'E') colour = '#bca510';
+                else if (leg.routeShortName == 'F') colour = '#8F6A51';
+                polyline.setStyle({ color: colour, weight: weight });
             }
             else polyline.setStyle({ color : this.getModeColor(leg.mode), weight: weight });
 
@@ -808,7 +815,7 @@ otp.modules.planner.PlannerModule =
     
     getModeColor : function(mode) {
         if(mode === "WALK") return '#444';
-        if(mode === "BICYCLE") return '#9944DD';
+        if(mode === "BICYCLE") return '#080';
         if(mode === "SUBWAY") return '#f00';
         if(mode === "RAIL") return '#b00';
         if(mode === "BUS") return '#FF7700';

--- a/src/client/js/otp/modules/planner/PlannerModule.js
+++ b/src/client/js/otp/modules/planner/PlannerModule.js
@@ -517,7 +517,9 @@ otp.modules.planner.PlannerModule =
     },
  
     planTrip : function(existingQueryParams, apiMethod) {
-    
+   
+    logGAEvent('click', 'link', 'plan trip');
+
         if(typeof this.planTripStart == 'function') this.planTripStart();
 
 	this._queryParams = existingQueryParams;


### PR DESCRIPTION
Changed itinerary widget logos to have minimum size and colors of routes and widgets logos for more visibility.
#261 In the "itinerary returned" widget, there is a trip summary at the top showing, through logos, the modes(bus,walk,bicycle) that the user have to take to follow the trip. Sometimes these logos are too small and not visible properly and even div width varies, so changed these logos to have a minimum size and fixed the div to have constant size.
#260 All the bullrunner bus routes are shown with same color in tripplanner, so when two bus are necessary to take in order to get to the destination it is not clear for the user that he need to step out of the bus at some point from the colored route. Changed the bull runner routes to have different colors(same colors used in layers) and changed the widget logo colors accordingly. And changed the bicycle route and widget logo color to enable more visibility.

Fixes #260 #261 
