### PR TITLE
Trimming the white space before searching for the user provided input . Fixes#257

### DIFF
--- a/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
@@ -306,7 +306,7 @@ otp.widgets.tripoptions.LocationsSelector =
        input.autocomplete({
              autoFocus: true,
              source: function(request, response) {
-                 this_.geocoders[this_.activeIndex].geocode(request.term, function(results) {
+                 this_.geocoders[this_.activeIndex].geocode(request.term.trim(), function(results) {
 
                      input.data("results", this_.getResultLookup(results));
 


### PR DESCRIPTION
Trimmed the white spaces when a user tries to search for a start or end place with extra white spaces.
Fixes #257
