### PR TITLE
Fix #311 caused by NPE upon setting of new start/end field

### DIFF
--- a/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
@@ -192,11 +192,17 @@ otp.widgets.tripoptions.LocationsSelector =
         }).appendTo(this.$());
         
         this.tripWidget.module.on("startChanged", $.proxy(function(latlng, name) {
-            $("#"+this.id+"-start").val(name || '(' + latlng.lat.toFixed(5) + ', ' + latlng.lng.toFixed(5) + ')');
+            if (latlng != null) 
+                $("#"+this.id+"-start").val(name || '(' + latlng.lat.toFixed(5) + ', ' + latlng.lng.toFixed(5) + ')');
+            else
+                $('#'+this.id+'-start').val(name);
         }, this));
 
         this.tripWidget.module.on("endChanged", $.proxy(function(latlng, name) {
-            $("#"+this.id+"-end").val(name || '(' + latlng.lat.toFixed(5) + ', ' + latlng.lng.toFixed(5) + ')');
+            if (latlng != null) 
+                $("#"+this.id+"-end").val(name || '(' + latlng.lat.toFixed(5) + ', ' + latlng.lng.toFixed(5) + ')');
+            else
+                $("#"+this.id+"-end").val(name);
         }, this));
 
     },


### PR DESCRIPTION
Fixes #311 

In my tests the observed behavior for start and end should now match the expected as in the issue - note it will also work regardless of whether the user actually selects from the geocoder dropdown and force the geocode upon planning a trip as usual.
