### PR TITLE
Add fix from upstream that prevents returning transit trips that

### DIFF
--- a/src/main/java/org/opentripplanner/routing/trippattern/FrequencyEntry.java
+++ b/src/main/java/org/opentripplanner/routing/trippattern/FrequencyEntry.java
@@ -65,6 +65,7 @@ public class FrequencyEntry implements Serializable {
             // this would work better for time window edges.
             if (dep < beg) return beg; // not quite right
             if (dep < end) return dep;
+            if (dep > end && time <= end) return end; 
         }
         return -1;
     }
@@ -82,6 +83,7 @@ public class FrequencyEntry implements Serializable {
             int dep = t - headway;
             if (dep > end) return end; // not quite right
             if (dep > beg) return dep;
+             if (dep < beg && t >= beg) return beg;
         }
         return -1;
     }


### PR DESCRIPTION
start before the requested time if the time is outside the normal schedule.
upstream #2318
