### PR TITLE
Fix to Map localization on Mobile

### DIFF
--- a/src/client/js/otp/core/Map.js
+++ b/src/client/js/otp/core/Map.js
@@ -276,7 +276,47 @@ otp.core.Map = otp.Class({
 		}				
 
         // Set initial map view and zoom when first GPS location found
-		this.queueView(e.latlng, otp.config.gpsZoom);
+		if (window.matchMedia("screen and (max-width: 768px)").matches) //Map localization on mobile
+		{
+			if (location.hash == "#trip")
+			{
+				this.queueView(new L.LatLng((e.latlng.lat + 0.00120),(e.latlng.lng)), otp.config.gpsZoom);
+			}
+			else if (location.hash == "#layers") 
+			{
+				this.queueView(new L.LatLng((e.latlng.lat),(e.latlng.lng - 0.00060)), otp.config.gpsZoom);
+			}
+			else if (location.hash == "#map") 
+			{
+				this.queueView(otp.config.initLatLng, otp.config.gpsZoom);
+			}
+			else //If the user didn't specify anything we check the cookies
+			{
+				var widgetUsedName = "widgetUsed=";
+				var widgetUsed = "trip";
+				var parts = document.cookie.split("; ");
+				for (var i = 0; i < parts.length; i++) // This will iterate throught all the combinaison of key and value
+				{
+					var part = parts[i];
+					if (part.indexOf(widgetUsedName) == 0) // This look if the key match 
+					{
+						widgetUsed =  part.substring(widgetUsedName.length);// This will return the value of the key "visited"
+					}
+				}
+				if(widgetUsed == "layers")
+				{
+					this.queueView(new L.LatLng((e.latlng.lat),(e.latlng.lng - 0.00060)), otp.config.gpsZoom);
+				}
+				else if (widgetUsed == "trip")
+				{
+					this.queueView(new L.LatLng((e.latlng.lat + 0.00120),(e.latlng.lng)), otp.config.gpsZoom);
+				}
+			}
+		}
+		else
+		{
+			this.queueView(e.latlng, otp.config.gpsZoom);
+		}
  	 }
 
 	 // Save the location on otp.core.Map for use elsewhere


### PR DESCRIPTION
When the map is opened on mobile, the blue circle indicating the user current location is hidden by either trip planner widget or layers widget. The starting screen may either contain layers widget or trip planner widget based on the users previous selection. So based on the starting screen, map is moved accordingly. Current location marker is positioned in open space below when Trip Planner widget is used as starting screen and in the open space on left side when Layers widget is used as starting screen.

Fixes #168
