### PR TITLE
Automatically minimize itineraries and trip planner widgets on mobile only. Fixes#167

### DIFF
--- a/src/client/js/otp/modules/planner/ItinerariesWidget.js
+++ b/src/client/js/otp/modules/planner/ItinerariesWidget.js
@@ -151,7 +151,22 @@ otp.widgets.ItinerariesWidget =
         });
 
         this.$().draggable({ cancel: "#"+divId });
-        
+        if (window.matchMedia("screen and (max-width: 768px)").matches){
+            this.minimize();
+            if(this.title.match(new RegExp(".*Itineraries.*")))
+            {
+                for (i in this.owner.getWidgetManager().widgets) 
+                {
+                    x = this.owner.getWidgetManager().widgets[i];
+                    if (x.title.match(new RegExp("Trip planner")))
+                    {
+                        x.minimize();
+                        x.isMinimized = true;
+                    }
+                    if(x.title.match(new RegExp("Layers"))) x.close();
+                }
+            }
+        }
     },
     
     clear : function() {


### PR DESCRIPTION
When a trip is planned, we automatically minimizes itineraries and trip planner widgets on mobile only. If layers widget is already open and minimized before a trip is planned, we also close it. 
By minimizing these trip planner and itineraries widget, user can have better view of the map route.
Fixes #167. 
