### PR TITLE
Support creating a link to a single location. Fixes#303

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -211,7 +211,13 @@ $(window).load(function() {
             }
         });
     }
-        
+    
+    window.addEventListener('popstate', function(event) {
+        if(!location.hash){
+            if(event.state) window.location = event.state.page;
+                else window.location = location.href;
+            }
+    }, false);
 });
 
 </script>
@@ -231,14 +237,12 @@ $(window).load(function() {
         for="main-menu">
             <li class="mdl-menu__item" id="tripPlannerButton"
             onClick=" document.cookie = 'widgetUsed=trip; expires=' + moment().add(moment.duration({'years':1})).format('ddd, D MMM YYYY HH:mm:ss zz') + ' UTC';
-                     document.location.hash = 'trip';
                      jQuery('#layersButton').removeClass('selected_item'); jQuery('#tripPlannerButton').addClass('selected_item');
                      javascript:webapp.modules[0].optionsWidget.show(); logGAEvent('click', 'link', 'trip planner'); "> 
             <i class="material-icons" >directions</i>
                 Trip planner</li>
             <li class="mdl-menu__item" id="layersButton"
                 onClick=" document.cookie = 'widgetUsed=layers; expires=' + moment().add(moment.duration({'years':1})).format('ddd, D MMM YYYY HH:mm:ss zz') + ' UTC';
-                          document.location.hash = 'layers';
                           jQuery('#tripPlannerButton').removeClass('selected_item'); jQuery('#layersButton').addClass('selected_item');
                           javascript:webapp.modules[0].layerWidget.show(); logGAEvent('click', 'link', 'layers'); ">
             <i class="material-icons" >layers</i>

--- a/src/client/js/otp/modules/planner/ItinerariesWidget.js
+++ b/src/client/js/otp/modules/planner/ItinerariesWidget.js
@@ -483,7 +483,9 @@ otp.widgets.ItinerariesWidget =
         
         tripSummaryFooter.append('Valid ' + moment().format(otp.config.locale.time.format));
         
-        var itinLink = this.constructLink(itin.tripPlan.queryParams, { itinIndex : index });
+        var itinLink = this.constructLink(itin.tripPlan.queryParams, { itinIndex : index});
+        if(window.history.state == null || !this.isURLPushedInHistory(itin.tripPlan.queryParams, window.history.state.page))
+        window.history.pushState({page:itinLink}, null, itinLink);
         if(this.showItineraryLink) {
             tripSummaryFooter.append(' | <a href="'+itinLink+'">Link to Itinerary</a>');
         }
@@ -699,6 +701,12 @@ otp.widgets.ItinerariesWidget =
             otp.util.Text.constructUrlParamString(_.extend(_.clone(queryParams), additionalParams));
     },
         
+    isURLPushedInHistory : function(queryParams, pageLink) {
+        var dLink = decodeURIComponent(pageLink);
+        return (dLink.includes(queryParams.fromPlace)
+                && dLink.includes(queryParams.toPlace) && dLink.includes("mode"))
+           ? true : false;
+    },    
     newMunicoderRequest : function(lat, lon) {
     
         this.municoderResultId++;

--- a/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/TripOptionsWidget.js
@@ -124,8 +124,20 @@ otp.widgets.tripoptions.TripOptionsWidget =
         if(this.autoPlan) {
             this.module.planTrip();
         }
+        else 
+            this.updateURL();
     },
     
+    updateURL : function() {
+        var params = {             
+                fromPlace: this.owner.startLatLng ? this.module.getStartOTPString() : undefined,
+                toPlace: this.owner.endLatLng ? this.module.getEndOTPString() : undefined,                
+            };
+        var link = otp.config.siteUrl + '?module=' + this.module.id + "&" +  
+        otp.util.Text.constructUrlParamString(_.extend(_.clone(params), {}));
+        if(window.history.state == null ||window.history.state.page != link)
+            window.history.pushState({page:link}, null, link);
+    },
     
     CLASS_NAME : "otp.widgets.TripWidget"
 });


### PR DESCRIPTION
Whenever user enters start or end location, the URL gets updated accordingly and the URL content is kept in sync with that of 'link to Itinerary'. Also added code to capture browser's back/forward click.

whenever user clicks on start/end flag, the popup contains 'link to the location' and when it's clicked, the corresponding location is opened in a new tab.

Fixes #303   
