### PR TITLE
Fix MyUSF campaign for google analytics

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -288,7 +288,11 @@ m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
 function init_ga() {
 
 is_myusf = navigator.userAgent.toLowerCase().indexOf('pyxismobile') > 0;
-if (is_myusf) ga('set', 'campaignSource', 'MyUSF Android');
+if (is_myusf) {
+    ga('set', 'campaignName', 'MyUSF');
+    ga('set', 'campaignSource', 'Tampa Maps');
+    ga('set', 'campaignMedium', 'Native App');
+}
 
 ga('send', 'pageview');
 


### PR DESCRIPTION
Currently, the MyUSF Android visits to the site are logged in analytics under:
- Acquisition, Other, MyUSF Android

This is due to the following notice from Analytics:

Property USF Maps is receiving hits with missing campaign parameters. Some examples (in the format "Source/Medium/Campaign") are:
    MyUSF Android/(not set)/(not set)

This patch changes the campaignName, Source, and Medium values when the myusf user-agent is detected to:
    MyUSF/Tampa Maps/Native App
