### PR TITLE
Automatically minimize itineraries and trip planner widgets on mobile only. Fixes#167

### DIFF
--- a/src/client/js/otp/modules/planner/ItinerariesWidget.js
+++ b/src/client/js/otp/modules/planner/ItinerariesWidget.js
@@ -36,12 +36,13 @@ otp.widgets.ItinerariesWidget =
     
     initialize : function(id, module) {
         this.module = module;
-
+        var closeOrMin = (window.matchMedia("screen and (max-width: 768px)").matches);
         otp.widgets.Widget.prototype.initialize.call(this, id, module, {
             title : otp.config.locale.widgets.ItinerariesWidget.title,
             cssClass : module.itinerariesWidgetCssClass || 'otp-defaultItinsWidget',
             resizable : true,
-            closeable : true,
+            closeable : !closeOrMin,
+            minimizable : closeOrMin,
             persistOnClose : true,
         });
         //this.$().addClass('otp-itinsWidget');
@@ -151,21 +152,14 @@ otp.widgets.ItinerariesWidget =
         });
 
         this.$().draggable({ cancel: "#"+divId });
-        if (window.matchMedia("screen and (max-width: 768px)").matches){
-            this.minimize();
-            if(this.title.match(new RegExp(".*Itineraries.*")))
+        if (window.matchMedia("screen and (max-width: 768px)").matches && this.title.match(new RegExp(".*Itineraries.*"))){
+            for (i in this.owner.getWidgetManager().widgets) 
             {
-                for (i in this.owner.getWidgetManager().widgets) 
-                {
-                    x = this.owner.getWidgetManager().widgets[i];
-                    if (x.title.match(new RegExp("Trip planner")))
-                    {
-                        x.minimize();
-                        x.isMinimized = true;
-                    }
-                    if(x.title.match(new RegExp("Layers"))) x.close();
-                }
+                x = this.owner.getWidgetManager().widgets[i];
+                if (x.title.match(new RegExp("Trip planner")))
+                    x.minimize();
             }
+            this.minimize();
         }
     },
     

--- a/src/client/js/otp/widgets/Widget.js
+++ b/src/client/js/otp/widgets/Widget.js
@@ -193,12 +193,29 @@ otp.widgets.Widget = otp.Class({
     minimize : function() {
         var this_ = this;
         this.hide();
+        
+        // To close Layers widget in mobile only, whenever it's minimized also
+        if(window.matchMedia("screen and (max-width: 768px)").matches && this.title.match(new RegExp("Layers"))) {
+            this.close();
+            return;
+        }
         this.minimizedTab = $('<div class="otp-minimized-tab">'+this.title+'</div>')
         .appendTo($('#otp-minimize-tray'))
         .click(function () {
             this_.unminimize();
         });
         this.isMinimized = true;
+        
+        // To get Itineraries minimized tab placed after Trip planner tab in mobile only.
+        if(window.matchMedia("screen and (max-width: 768px)").matches && this.title.match(new RegExp("Trip planner"))) {
+            for (i in this.owner.getWidgetManager().widgets) {
+                x = this.owner.getWidgetManager().widgets[i];
+                if (x.title.match(new RegExp(".*Itineraries.*")) && x.isMinimized) {
+                    x.minimizedTab.hide();
+                    x.minimize();
+                }
+            }
+        }
     },
 
     unminimize : function(tab) {


### PR DESCRIPTION
Along with automatically minimizing trip planner and itineraries widget when a trip is planned, we do close layers widget whenever it's minimized and this is done in mobile only.
the alignment of minimized tabs is ordered to always keep trip planner first and itineraries tab next to it in mobile only.
Updated the issue #317 

Fixes issue  #167 
