### PR TITLE
#262 Support - write batch script to add files to archive

### DIFF
--- a/zip.vbs
+++ b/zip.vbs
@@ -1,11 +1,17 @@
 Set objArgs = WScript.Arguments
 ZipFile = objArgs(1)
 Wscript.echo ZipFile
-Dim zip
-Set zip = CreateObject("Shell.Application").NameSpace(ZipFile)
 
 Dim objFSO
 Set objFSO = CreateObject("Scripting.FileSystemObject")
+
+'If zip file doesn't exist create a new one
+If (Not objFSO.fileExists(ZipFile)) then
+	objFSO.CreateTextFile(ZipFile, True).Write ""
+    End If
+
+Dim zip
+Set zip = CreateObject("Shell.Application").NameSpace(ZipFile)
 
 Set re = New RegExp
 re.Global     = True

--- a/zip.vbs
+++ b/zip.vbs
@@ -1,0 +1,29 @@
+Set objArgs = WScript.Arguments
+ZipFile = objArgs(1)
+Wscript.echo ZipFile
+Dim zip
+Set zip = CreateObject("Shell.Application").NameSpace(ZipFile)
+
+Dim objFSO
+Set objFSO = CreateObject("Scripting.FileSystemObject")
+
+Set re = New RegExp
+re.Global     = True
+re.IgnoreCase = False
+'pattern to match the filenames
+re.Pattern    = "requests\.[0-9\-]+\.log"
+objStartFolder = objArgs(0)
+Set objFolder = objFSO.GetFolder(objStartFolder)
+
+Set colFiles = objFolder.Files
+
+'iterates through all files in the folder
+For Each objFile in colFiles
+	If re.Test(objFile.Name) Then
+	FileName = objArgs(0)+"\"+ objFile.Name
+	zip.CopyHere(FileName)
+	Wscript.echo FileName
+    End If
+
+  Wscript.Sleep(1000) 'value need to be changed depending the file sizes.
+Next


### PR DESCRIPTION
We use an automated deployment system (Chef) to manage the production servers and they are currently logging trip planner requests to a file that gets 
rotated each day, and deleted after 7 days.  We can run this script nightly to add the log(s) to an archive so they can be kept beyond the 7 days. 
These log files are named requests.2016-07-28.log (requests.date.log) and current date file is simply requests.log. This script automatically adds all the logs files except current day file(request.log) to the specified zip file and skips those log files which are already present in zip file. The sleep time in the code(Wscript.Sleep(1000)) needs to be changed based on the file sizes.
Run Command: cscript  zip.vbs  path_to_log_files  path_to_zip_file
e.g., cscript zip.vbs C:\Scripts C:\Scripts\requests.zip
