### PR TITLE
Viewing itinerary link centers on real-time location. #Fixes326

### DIFF
--- a/src/client/js/otp/core/Map.js
+++ b/src/client/js/otp/core/Map.js
@@ -100,11 +100,13 @@ otp.core.Map = otp.Class({
         L.Map.include(!L.DomUtil.TRANSITION ? {} : {
         	_viewActions: [],
         	queueView: function(latlng, zoom) {
-        		if (this._animatingZoom) {
-        			this._viewActions.push([latlng, zoom]);
-        		}
-        		else {
-        			this.setView(latlng, zoom);
+        		if (!(location.href.includes("fromPlace") || location.href.includes("toPlace"))) {
+        			if (this._animatingZoom) {
+        				this._viewActions.push([latlng, zoom]);
+        			}
+        			else {
+        				this.setView(latlng, zoom);
+        			}
         		}
         	}
         });


### PR DESCRIPTION
If we open an itinerary link, the map is centering on real time location instead on itinerary. 
Fixed to center on itinerary.
Fixes #326 
