### PR TITLE
Readd layers and trip hash that was removed by PR #324

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -237,13 +237,13 @@ $(window).load(function() {
         for="main-menu">
             <li class="mdl-menu__item" id="tripPlannerButton"
             onClick=" document.cookie = 'widgetUsed=trip; expires=' + moment().add(moment.duration({'years':1})).format('ddd, D MMM YYYY HH:mm:ss zz') + ' UTC';
-                     jQuery('#layersButton').removeClass('selected_item'); jQuery('#tripPlannerButton').addClass('selected_item');
+                     document.location.hash = 'trip'; jQuery('#layersButton').removeClass('selected_item'); jQuery('#tripPlannerButton').addClass('selected_item');
                      javascript:webapp.modules[0].optionsWidget.show(); logGAEvent('click', 'link', 'trip planner'); "> 
             <i class="material-icons" >directions</i>
                 Trip planner</li>
             <li class="mdl-menu__item" id="layersButton"
                 onClick=" document.cookie = 'widgetUsed=layers; expires=' + moment().add(moment.duration({'years':1})).format('ddd, D MMM YYYY HH:mm:ss zz') + ' UTC';
-                          jQuery('#tripPlannerButton').removeClass('selected_item'); jQuery('#layersButton').addClass('selected_item');
+                          document.location.hash = 'layers'; jQuery('#tripPlannerButton').removeClass('selected_item'); jQuery('#layersButton').addClass('selected_item');
                           javascript:webapp.modules[0].layerWidget.show(); logGAEvent('click', 'link', 'layers'); ">
             <i class="material-icons" >layers</i>
                 Layers</li>


### PR DESCRIPTION
I tested the back and forward buttons with and without a start/end location and this patch does not break the functionality as far as I can tell.

(related to #303, PR #324)
