### PR TITLE
Add jQuery toPx function to calculate zoom padding at runtime

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -191,6 +191,33 @@
 var webapp = null;
 
 $(window).load(function() {
+
+    // http://stackoverflow.com/questions/10305993/jquery-javascript-convert-pixels-to-em-in-a-easy-way/13230903#13230903
+    // https://github.com/arasbm/jQuery-Pixel-Em-Converter
+    $.fn.toEm = function(settings){
+        settings = jQuery.extend({
+            scope: 'body'
+        }, settings);
+        var that = parseInt(this[0],10),
+            scopeTest = jQuery('<div style="display: none; font-size: 1em; margin: 0; padding:0; height: auto; line-height: 1; border:0;">&nbsp;</div>').appendTo(settings.scope),
+            scopeVal = scopeTest.height();
+        scopeTest.remove();
+        return (that / scopeVal).toFixed(8) + 'em';
+    };
+    $.fn.toPx = function(settings){
+        settings = jQuery.extend({
+            scope: 'body'
+        }, settings);
+        var that = parseFloat(this[0]),
+            scopeTest = jQuery('<div style="display: none; font-size: 1em; margin: 0; padding:0; height: auto; line-height: 1; border:0;">&nbsp;</div>').appendTo(settings.scope),
+            scopeVal = scopeTest.height();
+        scopeTest.remove();
+        return Math.round(that * scopeVal) + 'px';
+    };
+
+    otp.config['zoomPadding'][0] = parseInt(jQuery(otp.config['zoomPadding'][0]).toPx().replace("px", ""));
+    otp.config['zoomPadding'][1] = parseInt(jQuery(otp.config['zoomPadding'][1]).toPx().replace("px", ""));
+
     var templateUrls = [ //new Array(
         'js/otp/layers/layers-templates.html',
         'js/otp/widgets/widget-templates.html',

--- a/src/client/js/otp/config.js
+++ b/src/client/js/otp/config.js
@@ -39,6 +39,10 @@ L.layersIcon = L.DivIcon.extend({
 otp.config = {
     debug: false,
     locale: otp.locale.English,
+
+    // in EM (4.615em is 60px on regular desktop browsers) - converted to PX in index.html by jQuery function
+    // Used by js/otp/modules/planner/PlannerModule.js zoomOnMarkers, and drawItinerary
+    zoomPadding: [4.615, 4.615],  
     
     //All available locales
     //key is translation name. Must be the same as po file or .json file


### PR DESCRIPTION
Add toPx jQuery function to calculate pixels from em for padding at runtime - accommodating for possible variation on certain high DPI devices.

I changed the padding to be in js/otp/config.js as a hard-coded "4.615EM" which calculates to 60px on desktops, and should be higher on some mobile devices.
- [x] Confirm this works on mobile as expected

Related to #339 
