### PR TITLE
Fix #334 - Adjust EV popup template for new stations

### DIFF
--- a/src/client/js/otp/config.js
+++ b/src/client/js/otp/config.js
@@ -117,6 +117,7 @@ otp.config = {
     //if user does not allow location finding default location set
     initLatLng : new L.LatLng(28.061062, -82.413200), 
     mapBoundary: false,
+    usfTampaBounds: new L.latLngBounds(new L.latLng(28.054512, -82.426146), new L.latLng(28.069156, -82.401856)),
     initZoom : 15, /* Default zoom w/o GPS (15 = entire viewport big enough for Tampa campus) */
     minZoom : 13, /* Smaller numbers allow farther zooms (zoom OUT) */
     maxZoom : 18, /* Larger numbers allow closer zooms (zoom IN) */

--- a/src/client/js/otp/layers/layers-templates.html
+++ b/src/client/js/otp/layers/layers-templates.html
@@ -243,13 +243,21 @@ Operated by: {{operator}}<br>
 <div>
 <h3>Electric Vehicle Charging Station</h3>
 
+{{#note}}
+{{note}}
+<br>
+{{/note}}
+
+<br>
 Provided by <a href="https://na.chargepoint.com/charge_point" target="_blank">Charge Point</a>. <br>
 <br>
 
+{{#inTampaCampus}}
 <b>Please note:</b> A USF parking permit is required and the vehicle must be charging while using the space. There is no fee for using the charging station. However, there is a 4 hour daily limit. <br>
 <br>
 
 <a href="http://www.usf.edu/administrative-services/parking/parking/ev-charging-stations.aspx" target="_blank">More information</a>
+{{/inTampaCampus}}
 
 </div>
 </script>

--- a/src/client/js/otp/widgets/tripoptions/LayersWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/LayersWidget.js
@@ -222,6 +222,8 @@ otp.widgets.LayersWidget =
                     else if (y['locations'].split(',').length > 1) {
                        v = y['locations'].split(',');
                        latlng = [ parseFloat(v[0]), parseFloat(v[1]) ];
+
+                       vals['inTampaCampus'] = otp.config.usfTampaBounds.contains(L.latLng(latlng[0], latlng[1])) ? true : false;
                     }
                     else continue;
 

--- a/src/client/js/otp/widgets/tripoptions/LayersWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/LayersWidget.js
@@ -223,7 +223,7 @@ otp.widgets.LayersWidget =
                        v = y['locations'].split(',');
                        latlng = [ parseFloat(v[0]), parseFloat(v[1]) ];
 
-                       vals['inTampaCampus'] = otp.config.usfTampaBounds.contains(L.latLng(latlng[0], latlng[1])) ? true : false;
+                       vals['inTampaCampus'] = otp.config.usfTampaBounds.contains(L.latLng(latlng[0], latlng[1]));
                     }
                     else continue;
 


### PR DESCRIPTION
- Add inTampaCampus latLng bounds check for stations in the area surrounding Tampa campus - and disable the USF-specific notice if the node is outside
- Add support for amenity=charging_station nodes with `<tag k="note" />` in the template
#334
