### PR TITLE
Fix #362 - Update the pelias-client-library version to 1.0.1

### DIFF
--- a/opentripplanner-geocoder/pom.xml
+++ b/opentripplanner-geocoder/pom.xml
@@ -132,7 +132,7 @@
     <dependency>
       <groupId>edu.usf.cutr</groupId>    
       <artifactId>pelias-client-library</artifactId>    
-      <version>1.0.0</version>
+      <version>1.0.1</version>
     </dependency> 
  </dependencies>
 </project>


### PR DESCRIPTION
Additional improvements for this issue will be to switch from /search to /autocomplete endpoints based on discussion with Mapzen/Pelias developers
#362
