### PR TITLE
Add Github issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,19 @@
+**Summary:** 
+
+Summarize your issue in one sentence (what goes wrong, what did you expect to happen)
+
+**Steps to reproduce:** 
+
+How can we reproduce the issue?
+
+**Expected behavior:** 
+
+What did you expect the skill to do?
+
+**Observed behavior:** 
+
+What happened instead?  Describe your issue in detail here.
+
+**Plaftorm:** 
+
+What is the operating system and Java version of your machine?

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -14,6 +14,6 @@ What did you expect the skill to do?
 
 What happened instead?  Describe your issue in detail here.
 
-**Plaftorm:** 
+**Platform:** 
 
 What is the operating system and Java version of your machine?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,3 @@
+Please make sure these boxes are checked before submitting your pull request - thanks!
+
+- [ ] Run the unit tests with `mvn test` to make sure you didn't break anything

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,16 @@
+
+**Summary:**
+
+Summarize the changes in the pull request including how it relates to any issues (include the #number, or link them).
+
+**Expected behavior:** 
+
+Show screenshots for how you expect the pull request to work in your testing. (In case other devices exhibit different behavior).
+
+
 Please make sure these boxes are checked before submitting your pull request - thanks!
 
 - [ ] Run the unit tests with `mvn test` to make sure you didn't break anything
+- [ ] Format the title like "Fix #issue - short description of fix and changes"
+- [ ] Linked all relevant issues
+- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)


### PR DESCRIPTION
Auto-populates the Github issue and PR with these files - see https://github.com/blog/2111-issue-and-pull-request-templates for details.

@jmfield2 Please take a look and merge if all looks ok.  Let me know if there is anything else that should be in the templates that's not currently there.