### PR TITLE
Fix #371 - Add overflow:scroll to prevent the layer widget contents 

### DIFF
--- a/src/client/style.css
+++ b/src/client/style.css
@@ -695,6 +695,7 @@ div#otp-planner-optionsWidget-scollPanel {
 	font-family: "Helvetica Neue",Arial,Helvetica,sans-serif;	
 	text-align:left;
 	padding: 0 10px 10px 10px;
+	overflow: scroll;
 }
 
 .otp-layerView-inner fieldset { 


### PR DESCRIPTION
from overflowing the container on small screens.