### PR TITLE
Fix issue with Geolocation and Validation that would prevent errors from being displayed.

### DIFF
--- a/src/client/js/otp/core/Map.js
+++ b/src/client/js/otp/core/Map.js
@@ -207,8 +207,7 @@ otp.core.Map = otp.Class({
              * Binds the actions to the map events.
              */
             bindEvents: function(map) {
-                map.on('locationfound', this._onLocationFound, this);
-                map.on('locationerror', this._onLocationError, this);
+                map.on('locationerror', this.onLocationError, this);
                 map.on('unload', this.stop, this);
             },
 

--- a/src/client/js/otp/modules/planner/PlannerModule.js
+++ b/src/client/js/otp/modules/planner/PlannerModule.js
@@ -368,8 +368,12 @@ otp.modules.planner.PlannerModule =
                     desc.indexOf( "(" + obj.val().toUpperCase() + ")" ) == 0) {
 
         	        // Name matches, but latlng doesn't. Update the result
-                    if (inputSelected == 'start' && this.startLatLng != resultLatLng) obj[0].selectItem( key );
-                    else if (inputSelected == 'end' && this.endLatLng != resultLatLng) obj[0].selectItem( key );
+		    need_select = false;
+                    if (inputSelected == 'start' && this.startLatLng != resultLatLng) need_select = true;
+                    else if (inputSelected == 'end' && this.endLatLng != resultLatLng) need_select = true;
+
+		    // prevent clicking my location twice
+		    if (need_select && (desc != "My Location" || this._valid.indexOf(inputSelected + "_geocode") == -1)) obj[0].selectItem( key );
 
                     ret['pos'] = resultsList[key];
                     break;


### PR DESCRIPTION
**Summary:**

For reference, when a geolocation request is made in Chrome the user can close the box
by clicking "Allow", "Deny", or "X" (close).  The X is also considered a DENY and will
reject subsequent requests until the browser is refreshed.  This may manifest as 
incorrect "Please select .." messages when "My Location" is chosen, without a message
suggesting an issue with geolocation.

Also, This commit fixes an issue with such messages being shown multiple times per request
because of the failure but a missing check specifically for "My Location".

**Expected behavior:** 

On Chrome, when there is any error with geolocation the following message should appear ONCE per attempt (e.g, click on 'plan trip', or the location button).

![selection_030](https://cloud.githubusercontent.com/assets/3628509/20998666/7b9ed1f0-bcdd-11e6-8efc-f8b3fd745866.png)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "Fix #issue - short description of fix and changes"
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)

