### PR TITLE
Add Cache-Control header to POI JSON API

### DIFF
--- a/src/main/java/org/opentripplanner/api/resource/POIs.java
+++ b/src/main/java/org/opentripplanner/api/resource/POIs.java
@@ -28,6 +28,9 @@ import org.opentripplanner.routing.graph.Graph;
 import org.opentripplanner.routing.services.GraphService;
 import org.opentripplanner.util.model.EncodedPolylineBean;
 
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.ResponseBuilder;
+
 @Path("/routers/{routerId}/pois")
 @XmlRootElement
 public class POIs {
@@ -38,12 +41,12 @@ public class POIs {
 
 		@GET
 		@Produces({ MediaType.APPLICATION_JSON })
-		public Map<String, ArrayList<PoiNode>> get(@PathParam("routerId") String routerId,
+		public Response get(@PathParam("routerId") String routerId,
             @QueryParam("query") String query) {
 
 			Graph g = graphService.getGraph(routerId);
 			if (g == null) return null;
-		
+	
             // Map for result
             Map<String, ArrayList<PoiNode>> res = new HashMap<String, ArrayList<PoiNode>>();
             
@@ -69,7 +72,10 @@ public class POIs {
             }
 
             // Find all matching PoiNodes, and create JSON string
-            return q;
+
+	    // Allow POI response to be cached for up to a week
+            return Response.ok(q).header("Cache-Control", "max-age=86400").build();
+
 		}
 	
 }


### PR DESCRIPTION
**Summary:**

This adds a 1 day cache expiration date to the /otp/routers/default/pois endpoint so browsers can cache the result and save bandwidth on subsequent requests.  Note JSON is already included in the Grizzly compression configuration for response to be gzipped.

![selection_033](https://cloud.githubusercontent.com/assets/3628509/21128974/e8663038-c0cc-11e6-9851-422ca5970766.png)

**Expected behavior:** 

Uncached screenshot:
![selection_031](https://cloud.githubusercontent.com/assets/3628509/21128978/ef2c2e9a-c0cc-11e6-90b7-0c70c23b7700.png)

Cached screenshot:
![selection_032](https://cloud.githubusercontent.com/assets/3628509/21128985/f637a912-c0cc-11e6-9ab0-78ec4d1df018.png)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "Fix #issue - short description of fix and changes"
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
