### PR TITLE
Fix #392

### DIFF
--- a/src/client/js/otp/widgets/tripoptions/LayersWidget.js
+++ b/src/client/js/otp/widgets/tripoptions/LayersWidget.js
@@ -40,6 +40,8 @@ otp.widgets.LayersWidgetRouter = Backbone.Router.extend({
 
 		var fragment = "layers/" + Object.keys(self.state).join(",");
 
+	        sessionStorage.setItem("previousURL", location.origin + "/" + location.search);
+
 		self.navigate( fragment );
 	}
 


### PR DESCRIPTION
**Summary:**

Add the necessary URI to previousURL sessionStorage to prevent a conflict
between layersWidget hash fragment handling and trip planner/from/to markers

#392

**Expected behavior:** 

Prevent the browser from reloading unnecessarily after switching from a trip plan to layers and activating a layer.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "Fix #issue - short description of fix and changes"
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
