### PR TITLE
Fix #391 - Add dialogs for geolocation behaviors

### DIFF
--- a/src/client/js/otp/core/Map.js
+++ b/src/client/js/otp/core/Map.js
@@ -277,15 +277,50 @@ otp.core.Map = otp.Class({
 
 		// 40 accuracy for wifi, 22000 for wired/city center approximations
 		if (e.accuracy >= 22000) {
-			e.latlng = otp.config.initLatLng;
-			this.queueView(e.latlng, otp.config.initZoom);
+
+			dialogYesFn = (function(e, ctx) {
+				var original_pos = e;
+				var this_ = ctx;
+				return function() {
+					this_.queueView(original_pos.latlng, otp.config.initZoom);
+					webapp.map.geoLocationFound( original_pos );
+				}
+			})(e, this);
+		
+			dialogNoFn = (function(e) {
+				var this_ = e;
+				return function() {
+					this_.queueView(otp.config.initLatLng, otp.config.initZoom);
+				}
+			})(this);
+
+	                otp.widgets.Dialogs.showYesNoDialog("An inaccurate location was provided by your device.  Would you like to use this anyway?", "Location Unavailable", dialogYesFn, dialogNoFn );
+
 			return; // dont bother adding a marker 
 		}
 				
 		// if e.latlng is outside of map boundaries (tampa), recenter on USF			
 		if ( ! otp.config.mapBoundary.contains(e.latlng)) {
-			e.latlng = otp.config.initLatLng;
-			this.queueView(e.latlng, otp.config.initZoom);
+
+                        dialogYesFn = (function(e, ctx) {
+                                var original_pos = e;
+				var this_ = ctx;
+                                return function() {
+                                        this_.queueView(original_pos.latlng, otp.config.initZoom);
+                                        webapp.map.geoLocationFound( original_pos );
+                                
+                                }
+                        })(e, this);
+
+                        dialogNoFn = (function(e) {
+                                var this_ = e;
+                                return function() {
+                                        this_.queueView(otp.config.initLatLng, otp.config.initZoom);
+                                }
+                        })(this);
+                        
+                        otp.widgets.Dialogs.showYesNoDialog("You appear to be outside of the Tampa area.  Move the map to your current location now?", "Location Out of Range", dialogYesFn, dialogNoFn );
+
 			return; // and don't add a marker on first load
 		}				
 


### PR DESCRIPTION
**Summary:**

The dialogs describe the app behavior when location is out of the map bounds, or accuracy is too high and prompts the user to optionally ignore the error and move the map anyway.

Fix #391 

**Expected behavior:** 

![selection_036](https://cloud.githubusercontent.com/assets/3628509/21560429/396abafe-ce2d-11e6-993a-cf5611ae88ad.png)

![selection_035](https://cloud.githubusercontent.com/assets/3628509/21560430/3977f9ee-ce2d-11e6-93f3-1b38f132e63c.png)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `mvn test` to make sure you didn't break anything
- [x] Format the title like "Fix #issue - short description of fix and changes"
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
